### PR TITLE
Sprint 4 General Fixes

### DIFF
--- a/src/main/java/edu/tamu/app/service/GetItForMeService.java
+++ b/src/main/java/edu/tamu/app/service/GetItForMeService.java
@@ -1,5 +1,8 @@
 package edu.tamu.app.service;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -233,7 +236,11 @@ public class GetItForMeService {
                             // generate unique link for the current button
                             String linkHref = button.getLinkTemplate();
                             for (Map.Entry<String, String> entry : parameters.entrySet()) {
-                                linkHref = linkHref.replace("{" + entry.getKey() + "}", entry.getValue());
+                                try {
+                                    linkHref = linkHref.replace("{" + entry.getKey() + "}", URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8.toString()));
+                                } catch (UnsupportedEncodingException e) {
+                                    e.printStackTrace();
+                                }
                             }
 
                             logger.debug("We want the button with text: " + button.getLinkText());

--- a/src/main/java/edu/tamu/app/service/GetItForMeService.java
+++ b/src/main/java/edu/tamu/app/service/GetItForMeService.java
@@ -237,7 +237,7 @@ public class GetItForMeService {
                             String linkHref = button.getLinkTemplate();
                             for (Map.Entry<String, String> entry : parameters.entrySet()) {
                                 try {
-                                    linkHref = linkHref.replace("{" + entry.getKey() + "}", URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8.toString()));
+                                    linkHref = linkHref.replace("{" + entry.getKey() + "}", URLEncoder.encode((entry.getValue() != null) ? entry.getValue():"", StandardCharsets.UTF_8.toString()));
                                 } catch (UnsupportedEncodingException e) {
                                     e.printStackTrace();
                                 }

--- a/src/main/java/edu/tamu/app/service/VoyagerCatalogService.java
+++ b/src/main/java/edu/tamu/app/service/VoyagerCatalogService.java
@@ -204,7 +204,7 @@ class VoyagerCatalogService extends AbstractCatalogService {
                                 itemData);
                         //sleep for a moment between item requests to avoid triggering a 429 from the Voyager API
                         try {
-                            TimeUnit.MICROSECONDS.sleep(100);
+                            TimeUnit.MILLISECONDS.sleep(50);
                         } catch (InterruptedException e) {
                             e.printStackTrace();
                         }

--- a/src/main/java/edu/tamu/app/service/VoyagerCatalogService.java
+++ b/src/main/java/edu/tamu/app/service/VoyagerCatalogService.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -201,11 +202,18 @@ class VoyagerCatalogService extends AbstractCatalogService {
                         }
                         catalogItems.put(childNodes.item(j).getAttributes().getNamedItem("href").getTextContent(),
                                 itemData);
+                        //sleep for a moment between item requests to avoid triggering a 429 from the Voyager API
+                        try {
+                            TimeUnit.MICROSECONDS.sleep(100);
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
                     }
                 }
                 catalogHoldings.add(new CatalogHolding(marcRecordLeader, mfhd, recordValues.get("issn"), recordValues.get("isbn"), recordValues.get("title"), recordValues.get("author"), recordValues.get("publisher"),
                         recordValues.get("place"), recordValues.get("year"), recordValues.get("genre"), recordValues.get("edition"), fallBackLocationCode, new HashMap<String, Map<String, String>>(catalogItems)));
                 catalogItems.clear();
+
             }
             return catalogHoldings;
         } catch (IOException e) {

--- a/src/main/java/edu/tamu/app/service/VoyagerCatalogService.java
+++ b/src/main/java/edu/tamu/app/service/VoyagerCatalogService.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -34,6 +35,18 @@ import edu.tamu.weaver.utility.HttpUtility;
 class VoyagerCatalogService extends AbstractCatalogService {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
+    private void appendMapValue(Map<String,String> map, String key, String newValue) {
+        if (map.containsKey(key) && map.get(key) != null && !map.get(key).isEmpty()) {
+            addMapValue(map, key, map.get(key) + newValue);
+        } else {
+            addMapValue(map, key, newValue);
+        }
+    }
+
+    private void addMapValue(Map<String,String> map, String key, String newValue) {
+        map.put(key, (newValue != null ? newValue:""));
+    }
+
     /**
      * Fetches holdings from the Voyager API and translates them into
      * catalogHoldings
@@ -56,16 +69,9 @@ class VoyagerCatalogService extends AbstractCatalogService {
             doc.getDocumentElement().normalize();
             NodeList dataFields = doc.getElementsByTagName("datafield");
             int dataFieldCount = dataFields.getLength();
-            String issn = "";
-            String isbn = "";
-            String title = "";
-            String author = "";
-            String publisher = "";
-            String place = "";
-            String year = "";
-            String backupYear = "";
-            String genre = "";
-            String edition = "";
+
+            Map<String,String> recordValues = new HashMap<String,String>();
+            Map<String,String> recordBackupValues = new HashMap<String,String>();
 
             String marcRecordLeader = doc.getElementsByTagName("leader").item(0).getTextContent();
 
@@ -73,45 +79,72 @@ class VoyagerCatalogService extends AbstractCatalogService {
                 Node currentNode = dataFields.item(i);
                 switch (currentNode.getAttributes().getNamedItem("tag").getTextContent()) {
                     case "022":
-                        issn = currentNode.getChildNodes().item(0).getTextContent();
-                        genre = "journal";
+                        addMapValue(recordValues,"issn",currentNode.getChildNodes().item(0).getTextContent());
+                        addMapValue(recordValues,"genre","journal");
                     break;
                     case "020":
-                        isbn = currentNode.getChildNodes().item(0).getTextContent().split(" ")[0];
-                        genre = "book";
+                        addMapValue(recordValues,"isbn",currentNode.getChildNodes().item(0).getTextContent().split(" ")[0]);
+                        addMapValue(recordValues,"genre","book");
                     break;
                     case "245":
                         if (currentNode.getChildNodes().item(1) != null) {
-                            title = currentNode.getChildNodes().item(0).getTextContent()+currentNode.getChildNodes().item(1).getTextContent();
+                            addMapValue(recordValues,"title", currentNode.getChildNodes().item(0).getTextContent()+currentNode.getChildNodes().item(1).getTextContent());
                         } else {
-                            title = currentNode.getChildNodes().item(0).getTextContent();
+                            addMapValue(recordValues,"title", currentNode.getChildNodes().item(0).getTextContent());
                         }
                     break;
                     case "100":
-                        author = currentNode.getChildNodes().item(0).getTextContent();
+                        addMapValue(recordValues,"author", currentNode.getChildNodes().item(0).getTextContent());
                     break;
                     case "264":
                         NodeList publisherDataNodes = currentNode.getChildNodes();
                         int childCount = publisherDataNodes.getLength();
-                        place = publisherDataNodes.item(0).getTextContent();
-                        if (childCount > 1) {
-                            publisher = publisherDataNodes.item(1).getTextContent();
-                        }
-                        if (childCount > 2) {
-                            year = publisherDataNodes.item(2).getTextContent();
+                        for (int x=0;x<childCount;x++) {
+                            switch (publisherDataNodes.item(x).getAttributes().getNamedItem("code").getTextContent()) {
+                                case "a":
+                                    appendMapValue(recordValues, "place",publisherDataNodes.item(x).getTextContent());
+                                break;
+                                case "b":
+                                    appendMapValue(recordValues, "publisher",publisherDataNodes.item(x).getTextContent());
+                                break;
+                                case "c":
+                                    if (!recordValues.containsKey("year") || (recordValues.get("year") == null || recordValues.get("year").length() == 0)) {
+                                        addMapValue(recordValues,"year", publisherDataNodes.item(x).getTextContent());
+                                    }
+                                break;
+                            }
                         }
                     break;
                     case "260":
-                        backupYear = currentNode.getChildNodes().item(2).getTextContent();
+                        NodeList dataNodes = currentNode.getChildNodes();
+                        childCount = dataNodes.getLength();
+                        for (int x=0;x<childCount;x++) {
+                            switch (dataNodes.item(x).getAttributes().getNamedItem("code").getTextContent()) {
+                                case "a":
+                                    appendMapValue(recordBackupValues, "place",dataNodes.item(x).getTextContent());
+                                break;
+                                case "b":
+                                    appendMapValue(recordBackupValues, "publisher", dataNodes.item(x).getTextContent());
+                                break;
+                                case "c":
+                                    addMapValue(recordBackupValues,"year", recordBackupValues.get("year") + dataNodes.item(x).getTextContent());
+                                break;
+                            }
+                        }
                     break;
                     case "250":
-                        edition = currentNode.getChildNodes().item(0).getTextContent();
+                        addMapValue(recordValues,"edition", currentNode.getChildNodes().item(0).getTextContent());
                     break;
                 }
             }
 
-            if (year == null) {
-                year = backupYear;
+            //apply backup values if needed and available
+            Iterator<String> bpIterator = recordBackupValues.keySet().iterator();
+            while (bpIterator.hasNext()) {
+                String key = bpIterator.next();
+                if (!recordValues.containsKey(key) || (recordValues.get(key) == null || recordValues.get(key).length() == 0)) {
+                    addMapValue(recordValues,key,recordBackupValues.get(key));
+                }
             }
 
             logger.debug("Asking for holdings from: " + getAPIBase() + "record/" + bibId + "/holdings?view=items");
@@ -139,7 +172,7 @@ class VoyagerCatalogService extends AbstractCatalogService {
                 String fallBackLocationCode = childNodes.item(1).getChildNodes().item(0).getTextContent();
                 logger.debug("MarcRecordLeader: " + marcRecordLeader);
                 logger.debug("MFHD: " + mfhd);
-                logger.debug("ISBN: " + isbn);
+                logger.debug("ISBN: " + recordValues.get("isbn"));
                 logger.debug("Item URL: " + childNodes.item(1).getAttributes().getNamedItem("href").getTextContent());
                 logger.debug("Fallback Location: " + fallBackLocationCode);
 
@@ -170,8 +203,8 @@ class VoyagerCatalogService extends AbstractCatalogService {
                                 itemData);
                     }
                 }
-                catalogHoldings.add(new CatalogHolding(marcRecordLeader, mfhd, issn, isbn, title, author, publisher,
-                        place, year, genre, edition, fallBackLocationCode, new HashMap<String, Map<String, String>>(catalogItems)));
+                catalogHoldings.add(new CatalogHolding(marcRecordLeader, mfhd, recordValues.get("issn"), recordValues.get("isbn"), recordValues.get("title"), recordValues.get("author"), recordValues.get("publisher"),
+                        recordValues.get("place"), recordValues.get("year"), recordValues.get("genre"), recordValues.get("edition"), fallBackLocationCode, new HashMap<String, Map<String, String>>(catalogItems)));
                 catalogItems.clear();
             }
             return catalogHoldings;

--- a/src/main/resources/buttons.properties
+++ b/src/main/resources/buttons.properties
@@ -35,8 +35,9 @@ GetIt4DaysButton.locationCodes=rs,hdr;rs,jlf
 #GetIt4DaysButton.itemStatusCodes=
 GetIt4DaysButton.linkText=Get It: 4 days
 GetIt4DaysButton.SID=remotestorage
-GetIt4DaysButton.templateParameterKeys=sid,title,author,isbn,issn,publisher,genre,place,itemBarcode,year,edition
-GetIt4DaysButton.templateUrl=getitforme.library.tamu.edu/illiad/EVANSLocal/openurl.asp?Action=10&Form=30&sid={sid}&title={title}&author={author}&isbn={isbn}&issn={issn}&publisher={publisher}&genre={genre}&rfe_dat={itemBarcode}&place={place}&loanDate={year}&loanEdition={edition}
+GetIt4DaysButton.templateParameterKeys=sid,title,author,isbn,issn,publisher,genre,place,itemBarcode,callNumber,year,edition
+GetIt4DaysButton.templateUrl=getitforme.library.tamu.edu/illiad/EVANSLocal/openurl.asp?Action=10&Form=30&sid={sid}&title={title}&author={author}&isbn={isbn}&issn={issn}&publisher={publisher}&genre={genre}&rfe_dat={callNumber}&place={place}&loanDate={year}&loanEdition={edition}&Notes={itemBarcode}
+GetIt4DaysButton.cssClasses=button-remotestorage
 
 #This property is delimited by semicolons because valid Voyager location codes can contain commas
 GetIt1WeekButton.locationCodes=base;bsc;curr;curr,text;nbs;stk;stk,mov1;tdoc;udoc;wein;psel,stk;west,audio;west,nbs;west,stk;west,udoc


### PR DESCRIPTION
Addresses some or all of B03849, B03850, B03851, B03852, B03855

- Encodes query parameter values for all button links
- Refactors VoyagerCatalogService to support primary and fallback values in a generalized way
- Explicitly extract values from record xml by code attribute
- Properly reconstruct full field values across subfields where appropriate