### PR TITLE
[B03958] Update default button behavior to be per item

### DIFF
--- a/src/main/java/edu/tamu/app/service/GetItForMeService.java
+++ b/src/main/java/edu/tamu/app/service/GetItForMeService.java
@@ -44,6 +44,8 @@ import edu.tamu.app.utilities.sort.VolumeComparator;
 @Service
 public class GetItForMeService {
 
+    private static final int DEFAULT_THRESHOLD = 100;
+
     @Autowired
     private CatalogServiceFactory catalogServiceFactory;
 
@@ -238,7 +240,7 @@ public class GetItForMeService {
                         }
                     }
                 } else {
-                    if (holding.getCatalogItems().size() > 100) {
+                    if (holding.getCatalogItems().size() > DEFAULT_THRESHOLD) {
                         holding.getCatalogItems().forEach((uri, itemData) -> {
                             Map<String, String> parameters = new HashMap<String,String>();
                             Map<String, String> defaultButtonContent = new HashMap<String, String>();
@@ -392,4 +394,5 @@ public class GetItForMeService {
 
         return parameters;
     }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -84,3 +84,4 @@ app.http.timeout: 10000
 
 app.defaultButton.templateParameterKeys: title, author, publisher, genre, place, year, edition, isxn, oclc, mfhd
 app.defaultButton.templateUrl: getitforme.library.tamu.edu/illiad/EvansLocal/openurl.asp?Action=10&Form=30&LoanAuthor={author}&LoanPublisher={publisher}&sid={sid}&LoanTitle={title}&isxn={isxn}&genre={genre}&LoanDate={year}&LoanEdition={edition}&LoanPlace={place}&Note={oclc}|{mfhd}
+app.defaultButton.SID: default


### PR DESCRIPTION
Now relying on holding level item data.

This means there's no need for item level API requests, but also limits us to a subset of the relevant item data.

This isn't enough data to test the configurable buttons, but is enough to generate the default button.