### PR TITLE
Changes for EBSCO implementation

### DIFF
--- a/src/main/java/edu/tamu/app/controller/CatalogAccessController.java
+++ b/src/main/java/edu/tamu/app/controller/CatalogAccessController.java
@@ -49,7 +49,7 @@ public class CatalogAccessController {
 	 */
 	@RequestMapping("/get-html-buttons")
 	public ApiResponse getHtmlButtonsByBibId(@RequestParam(value="catalogName",defaultValue="evans") String catalogName, @RequestParam("bibId") String bibId) {
-		Map<String, ButtonPresentation> presentableHoldings = getItForMeService.getButtonDataByBibId(catalogName, bibId);
+		Map<String, ButtonPresentation> presentableHoldings = getItForMeService.getButtonDataByBibId(catalogName, bibId, null);
 		if (presentableHoldings != null) {
             Map<String,List<String>> buttonContents = new HashMap<String,List<String>>();
             for (Map.Entry<String, ButtonPresentation> entry : presentableHoldings.entrySet()) {
@@ -72,8 +72,8 @@ public class CatalogAccessController {
 	 */
 
 	@RequestMapping("/get-buttons")
-	public ApiResponse getButtonsByBibId(@RequestParam(value="catalogName",defaultValue="evans") String catalogName, @RequestParam("bibId") String bibId) {
-		Map<String,ButtonPresentation> buttonData = getItForMeService.getButtonDataByBibId(catalogName, bibId);
+	public ApiResponse getButtonsByBibId(@RequestParam(value="catalogName",defaultValue="evans") String catalogName, @RequestParam("bibId") String bibId, @RequestParam(value="itemKey",required=false) String itemKey) {
+		Map<String,ButtonPresentation> buttonData = getItForMeService.getButtonDataByBibId(catalogName, bibId, itemKey);
 		if (buttonData != null) {
 			return new ApiResponse(SUCCESS,buttonData);
 		}

--- a/src/main/java/edu/tamu/app/controller/CatalogAccessController.java
+++ b/src/main/java/edu/tamu/app/controller/CatalogAccessController.java
@@ -49,7 +49,7 @@ public class CatalogAccessController {
 	 */
 	@RequestMapping("/get-html-buttons")
 	public ApiResponse getHtmlButtonsByBibId(@RequestParam(value="catalogName",defaultValue="evans") String catalogName, @RequestParam("bibId") String bibId) {
-		Map<String, ButtonPresentation> presentableHoldings = getItForMeService.getButtonDataByBibId(catalogName, bibId, null);
+		Map<String, ButtonPresentation> presentableHoldings = getItForMeService.getButtonDataByBibId(catalogName, bibId);
 		if (presentableHoldings != null) {
             Map<String,List<String>> buttonContents = new HashMap<String,List<String>>();
             for (Map.Entry<String, ButtonPresentation> entry : presentableHoldings.entrySet()) {
@@ -72,8 +72,8 @@ public class CatalogAccessController {
 	 */
 
 	@RequestMapping("/get-buttons")
-	public ApiResponse getButtonsByBibId(@RequestParam(value="catalogName",defaultValue="evans") String catalogName, @RequestParam("bibId") String bibId, @RequestParam(value="itemKey",required=false) String itemKey) {
-		Map<String,ButtonPresentation> buttonData = getItForMeService.getButtonDataByBibId(catalogName, bibId, itemKey);
+	public ApiResponse getButtonsByBibId(@RequestParam(value="catalogName",defaultValue="evans") String catalogName, @RequestParam("bibId") String bibId) {
+		Map<String,ButtonPresentation> buttonData = getItForMeService.getButtonDataByBibId(catalogName, bibId);
 		if (buttonData != null) {
 			return new ApiResponse(SUCCESS,buttonData);
 		}

--- a/src/main/java/edu/tamu/app/model/CatalogHolding.java
+++ b/src/main/java/edu/tamu/app/model/CatalogHolding.java
@@ -27,12 +27,13 @@ public class CatalogHolding {
     private String fallbackLocationCode;
     private String edition;
     private String oclc;
+    private String recordId;
     private boolean largeVolume = false;
 
     private Map<String, Map<String, String>> catalogItems = new HashMap<String, Map<String, String>>();
 
     public CatalogHolding(String marcRecordLeader, String mfhd, String issn, String isbn, String title, String author,
-            String publisher, String place, String year, String genre, String edition, String fallBackLocationCode, String oclc,
+            String publisher, String place, String year, String genre, String edition, String fallBackLocationCode, String oclc, String recordId,
             Map<String, Map<String, String>> catalogItems) {
         this.setMarcRecordLeader(marcRecordLeader);
         this.setMfhd(mfhd);
@@ -48,12 +49,13 @@ public class CatalogHolding {
         this.setEdition(edition);
         this.setFallbackLocationCode(fallBackLocationCode);
         this.setOclc(oclc);
+        this.setRecordId(recordId);
     }
 
     public CatalogHolding(String marcRecordLeader, String mfhd, String issn, String isbn, String title, String author,
-            String publisher, String place, String year, String genre, String edition, String fallBackLocationCode, String oclc,
+            String publisher, String place, String year, String genre, String edition, String fallBackLocationCode, String oclc, String recordId,
             boolean largeVolume, Map<String, Map<String, String>> catalogItems) {
-        this(marcRecordLeader, mfhd, issn, isbn, title, author, publisher, place, year, genre, edition, fallBackLocationCode, oclc, catalogItems);
+        this(marcRecordLeader, mfhd, issn, isbn, title, author, publisher, place, year, genre, edition, fallBackLocationCode, oclc, recordId, catalogItems);
         this.setLargeVolume(largeVolume);
     }
 
@@ -159,6 +161,14 @@ public class CatalogHolding {
 
     public void setOclc(String oclc) {
         this.oclc = oclc;
+    }
+
+    public String getRecordId() {
+        return recordId;
+    }
+
+    public void setRecordId(String recordId) {
+        this.recordId = recordId;
     }
 
     public Map<String, Map<String, String>> getCatalogItems() {

--- a/src/main/java/edu/tamu/app/service/GetItForMeService.java
+++ b/src/main/java/edu/tamu/app/service/GetItForMeService.java
@@ -193,7 +193,7 @@ public class GetItForMeService {
      * @return Map<String,List<Map<String,String>>>
      */
 
-    public Map<String,ButtonPresentation> getButtonDataByBibId(String catalogName, String bibId, String itemKey) {
+    public Map<String,ButtonPresentation> getButtonDataByBibId(String catalogName, String bibId) {
         List<CatalogHolding> catalogHoldings = this.getHoldingsByBibId(catalogName, bibId);
         if (catalogHoldings != null) {
             logger.debug("\n\nCATALOG HOLDINGS FOR " + bibId);
@@ -268,8 +268,8 @@ public class GetItForMeService {
                         presentableHoldings.put(holding.getMfhd(), new ButtonFormPresentation(holdingButtons));
                     } else {
                         // Path 3: The 'normal' approach: Check all the items for each holding and create a button if a given item passes the tests
-                        holding.getCatalogItems().forEach((uri, itemData) -> {
-                            logger.debug("Checking holding URI: " + uri);
+                        holding.getCatalogItems().forEach((itemIdentifier, itemData) -> {
+                            logger.debug("Checking holding URI: " + itemIdentifier);
                             // check all registered button for each item
                             for (GetItForMeButton button : this.getRegisteredButtons(catalogName)) {
                                 logger.debug("Analyzing: " + button.toString());
@@ -335,10 +335,8 @@ public class GetItForMeService {
 
                                     buttonContent.put("linkHref", linkHref);
                                     buttonContent.put("cssClasses", "button-gifm" + ((button.getCssClasses() != null) ? " "+button.getCssClasses():""));
-
-                                    if (itemKey != null && itemData.containsKey(itemKey)) {
-                                        buttonContent.put("itemKey", itemData.get(itemKey));
-                                    }
+                                    //add the item's unique identifier to the corresponding button
+                                    buttonContent.put("itemKey", itemIdentifier);
 
                                     // add the button to the list for the holding's MFHD
                                     //presentableHoldings.get(holding.getMfhd()).add(buttonContent);

--- a/src/main/java/edu/tamu/app/service/GetItForMeService.java
+++ b/src/main/java/edu/tamu/app/service/GetItForMeService.java
@@ -369,7 +369,7 @@ public class GetItForMeService {
         // these template parameter keys are a special case, and come from the parent
         // holding, rather than the item data itself
         String[] getParameterFromHolding = { "title", "author", "publisher",
-                "genre", "place", "year", "edition", "oclc", "mfhd" };
+                "genre", "place", "year", "edition", "oclc", "mfhd", "recordId" };
 
         for (String parameterName : getParameterFromHolding) {
             if (parameters.containsKey(parameterName)) {

--- a/src/main/java/edu/tamu/app/service/GetItForMeService.java
+++ b/src/main/java/edu/tamu/app/service/GetItForMeService.java
@@ -193,7 +193,7 @@ public class GetItForMeService {
      * @return Map<String,List<Map<String,String>>>
      */
 
-    public Map<String,ButtonPresentation> getButtonDataByBibId(String catalogName, String bibId) {
+    public Map<String,ButtonPresentation> getButtonDataByBibId(String catalogName, String bibId, String itemKey) {
         List<CatalogHolding> catalogHoldings = this.getHoldingsByBibId(catalogName, bibId);
         if (catalogHoldings != null) {
             logger.debug("\n\nCATALOG HOLDINGS FOR " + bibId);
@@ -336,6 +336,9 @@ public class GetItForMeService {
                                     buttonContent.put("linkHref", linkHref);
                                     buttonContent.put("cssClasses", "button-gifm" + ((button.getCssClasses() != null) ? " "+button.getCssClasses():""));
 
+                                    if (itemKey != null && itemData.containsKey(itemKey)) {
+                                        buttonContent.put("itemKey", itemData.get(itemKey));
+                                    }
 
                                     // add the button to the list for the holding's MFHD
                                     //presentableHoldings.get(holding.getMfhd()).add(buttonContent);
@@ -353,6 +356,8 @@ public class GetItForMeService {
                                 Collections.sort(holdingButtons, new VolumeComparator());
                             }
                             presentableHoldings.put(holding.getMfhd(), new ButtonLinkPresentation(holdingButtons));
+                        } else {
+                            presentableHoldings.put(holding.getMfhd(), null);
                         }
                     }
                 }

--- a/src/main/java/edu/tamu/app/service/VoyagerCatalogService.java
+++ b/src/main/java/edu/tamu/app/service/VoyagerCatalogService.java
@@ -81,6 +81,15 @@ class VoyagerCatalogService extends AbstractCatalogService {
             Map<String,String> recordBackupValues = new HashMap<String,String>();
 
             String marcRecordLeader = doc.getElementsByTagName("leader").item(0).getTextContent();
+            NodeList controlFields = doc.getElementsByTagName("controlfield");
+            int controlFieldsCount = controlFields.getLength();
+
+            for (int i = 0; i < controlFieldsCount; i++) {
+                Node currentControlNode = controlFields.item(i);
+                if (currentControlNode.getAttributes().getNamedItem("tag") != null && currentControlNode.getAttributes().getNamedItem("tag").getTextContent().contentEquals("001")) {
+                    addMapValue(recordValues,"recordId",currentControlNode.getChildNodes().item(0).getTextContent());
+                }
+            }
 
             for (int i = 0; i < dataFieldCount; i++) {
                 Node currentNode = dataFields.item(i);
@@ -283,8 +292,9 @@ class VoyagerCatalogService extends AbstractCatalogService {
                         }
                     }
                 }
+                logger.info("holdingtime: "+recordValues.get("recordId"));
                 catalogHoldings.add(new CatalogHolding(marcRecordLeader, mfhd, recordValues.get("issn"), recordValues.get("isbn"), recordValues.get("title"), recordValues.get("author"), recordValues.get("publisher"),
-                        recordValues.get("place"), recordValues.get("year"), recordValues.get("genre"), recordValues.get("edition"), fallbackLocationCode, recordValues.get("oclc"), validLargeVolume, new HashMap<String, Map<String, String>>(catalogItems)));
+                        recordValues.get("place"), recordValues.get("year"), recordValues.get("genre"), recordValues.get("edition"), fallbackLocationCode, recordValues.get("oclc"), recordValues.get("recordId"), validLargeVolume, new HashMap<String, Map<String, String>>(catalogItems)));
                 catalogItems.clear();
             }
             return catalogHoldings;

--- a/src/main/resources/buttons.properties
+++ b/src/main/resources/buttons.properties
@@ -131,6 +131,6 @@ PurchaseItForMeButton.name=Purchase it
 PurchaseItForMeButton.locationCodes=pda,print
 PurchaseItForMeButton.SID=Purchase
 PurchaseItForMeButton.linkText=Purchase It For Me
-PurchaseItForMeButton.templateParameterKeys=sid,title,author,isxn,publisher,genre,year,place
-PurchaseItForMeButton.templateUrl=library.tamu.edu/formsprocessing/suggest-a-purchase.php?Action=10&Form=30&sid={sid}&title={title}&author={author}&issn={isxn}&publisher={publisher}&genre={genre}&loanDate={year}&place={place}
+PurchaseItForMeButton.templateParameterKeys=sid,title,author,isxn,publisher,genre,year,place,recordId
+PurchaseItForMeButton.templateUrl=library.tamu.edu/formsprocessing/suggest-a-purchase.php?Action=10&Form=30&sid={sid}&title={title}&author={author}&issn={isxn}&publisher={publisher}&genre={genre}&loanDate={year}&place={place}&bibid={recordId}
 PurchaseItForMeButton.catalog=evans


### PR DESCRIPTION
Adds an item identifier to the button to help clients match the returned button to its corresponding item.

The service will now return a null entry for a holding with no matching buttons, instead of leaving that holding out of the results.

Adds recordId value to holding.