### PR TITLE
[89] Blocks endpoint and pseudo FOLIO implementation

### DIFF
--- a/service/src/main/java/edu/tamu/catalog/controller/PatronController.java
+++ b/service/src/main/java/edu/tamu/catalog/controller/PatronController.java
@@ -56,4 +56,19 @@ public class PatronController {
             .body(loanItems);
     }
 
+    /**
+     * Checks block status for a patron.
+     *
+     * @param CatalogService catalogService (resolved by query parameter catalogName)
+     * @param String uin
+     * @return
+     */
+    @GetMapping("/{uin}/block")
+    public @ResponseBody ResponseEntity<Boolean> getBlockStatus(
+        @DefaultCatalog("folio") CatalogService catalogService,
+        @PathVariable(required = true) String uin
+    ) throws Exception {
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(catalogService.getBlockStatus(uin));
+    }
 }

--- a/service/src/main/java/edu/tamu/catalog/service/CatalogService.java
+++ b/service/src/main/java/edu/tamu/catalog/service/CatalogService.java
@@ -25,4 +25,6 @@ public interface CatalogService {
 
     List<LoanItem> getLoanItems(String uin) throws Exception;
 
+    Boolean getBlockStatus(String uin) throws Exception;
+
 }

--- a/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
+++ b/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
@@ -207,9 +207,16 @@ public class FolioCatalogService implements CatalogService {
         return list;
     }
 
+    @Override
+    public Boolean getBlockStatus(String uin) throws Exception {
+        //for now, no FOLIO user will be blocked
+        //leave the exception throw so the interface is future stable
+        return false;
+    }
+
     /**
      * Okapi request method not requiring a request body. i.e. HEAD, GET, DELETE
-     * 
+     *
      * @param <T> generic class for response body type
      * @param url String
      * @param method HttpMethod
@@ -450,7 +457,7 @@ public class FolioCatalogService implements CatalogService {
 
     /**
      * Okapi request method to attempt one token refresh and retry if request unauthorized.
-     * 
+     *
      * @param <T> generic class for response body type
      * @param attempt int
      * @param url String

--- a/service/src/main/java/edu/tamu/catalog/service/VoyagerCatalogService.java
+++ b/service/src/main/java/edu/tamu/catalog/service/VoyagerCatalogService.java
@@ -255,6 +255,11 @@ public class VoyagerCatalogService implements CatalogService {
         throw new UnsupportedOperationException("Not supported by the requested catalog.");
     }
 
+    @Override
+    public Boolean getBlockStatus(String uin) throws Exception {
+        throw new UnsupportedOperationException("Not supported by the requested catalog.");
+    }
+
     private Map<String, String> buildCoreRecord(String bibId) {
         String url = properties.getBaseUrl() + "/record/" + bibId + "/?view=full";
         logger.debug("Asking for Record from: {}", url);

--- a/service/src/test/java/edu/tamu/catalog/controller/PatronControllerTest.java
+++ b/service/src/test/java/edu/tamu/catalog/controller/PatronControllerTest.java
@@ -62,6 +62,7 @@ public class PatronControllerTest {
     private static final String VOYAGER_CATALOG = "msl";
     private static final String LOANS_ENDPOINT = "loans";
     private static final String FINES_ENDPOINT = "fines";
+    private static final String BLOCK_ENDPOINT = "block";
 
     @Value("classpath:mock/patron/account.json")
     private Resource patronAccountResource;
@@ -127,6 +128,31 @@ public class PatronControllerTest {
             fieldWithPath("[].author").description("The author of the loan item.")
         );
         getEndpointWithMockMVC(getLoansUrl(), LOANS_ENDPOINT, pathParameters, requestParameters, responseFields);
+    }
+
+    @Test
+    public void testBlockMockMVC() throws Exception {
+        PathParametersSnippet pathParameters = pathParameters(
+                parameterWithName("uin").description("The patron UIN.")
+            );
+
+        RequestParametersSnippet requestParameters = requestParameters(
+            parameterWithName("catalogName").description("The name of the catalog to use.").optional()
+        );
+
+        mockMvc.perform(get("/patron/{uin}/" + BLOCK_ENDPOINT, UIN)
+                .contentType(MediaType.APPLICATION_JSON)
+            )
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+        .andDo(
+            document(
+                "patron/" + BLOCK_ENDPOINT,
+                pathParameters,
+                requestParameters
+            )
+        );
+        restServer.verify();
     }
 
     @Test


### PR DESCRIPTION
Resolves #89 

Adds a patron controller endpoint for blocks and implements an always unblocked FOLIO Catalog Service implementation.