### PR TITLE
Issue 125: Loans, FeeFines (Charges), and Holds should all include itemId as well as instanceId.

### DIFF
--- a/domain/src/main/java/edu/tamu/catalog/domain/model/FeeFine.java
+++ b/domain/src/main/java/edu/tamu/catalog/domain/model/FeeFine.java
@@ -13,9 +13,13 @@ import lombok.NoArgsConstructor;
 @Data
 public class FeeFine {
 
-    private Double amount;
-
     private String fineId;
+
+    private String itemId;
+
+    private String instanceId;
+
+    private Double amount;
 
     private String fineType;
 

--- a/domain/src/main/java/edu/tamu/catalog/domain/model/HoldRequest.java
+++ b/domain/src/main/java/edu/tamu/catalog/domain/model/HoldRequest.java
@@ -17,6 +17,8 @@ public class HoldRequest {
 
     private String itemId;
 
+    private String instanceId;
+
     private String requestType;
 
     private String itemTitle;

--- a/domain/src/main/java/edu/tamu/catalog/domain/model/HoldingsRecord.java
+++ b/domain/src/main/java/edu/tamu/catalog/domain/model/HoldingsRecord.java
@@ -13,6 +13,8 @@ import lombok.NoArgsConstructor;
 @Data
 public class HoldingsRecord {
 
+    private String recordId;
+
     private String marcRecordLeader;
 
     private String mfhd;
@@ -38,8 +40,6 @@ public class HoldingsRecord {
     private String edition;
 
     private String oclc;
-
-    private String recordId;
 
     private String callNumber;
 

--- a/domain/src/test/java/edu/tamu/catalog/domain/model/FeeFineTest.java
+++ b/domain/src/test/java/edu/tamu/catalog/domain/model/FeeFineTest.java
@@ -18,13 +18,15 @@ public class FeeFineTest {
     @Test
     public void testCreateAllArgs() {
         final Date now = new Date();
-        final FeeFine feeFine = new FeeFine(1.0, "fineId", "fineType", now, "itemTitle");
+        final FeeFine feeFine = new FeeFine("fineId", "itemId", "instanceId", 1.0, "fineType", now, "itemTitle");
 
         assertNotNull(feeFine);
         assertNotNull(feeFine.getFineDate());
 
-        assertEquals(1.0, feeFine.getAmount(), 0);
         assertEquals("fineId", feeFine.getFineId());
+        assertEquals("itemId", feeFine.getItemId());
+        assertEquals("instanceId", feeFine.getInstanceId());
+        assertEquals(1.0, feeFine.getAmount(), 0);
         assertEquals("fineType", feeFine.getFineType());
         assertEquals(now.toString(), feeFine.getFineDate().toString());
         assertEquals("itemTitle", feeFine.getItemTitle());
@@ -36,8 +38,10 @@ public class FeeFineTest {
 
         assertNotNull(feeFine);
 
-        assertNull(feeFine.getAmount());
         assertNull(feeFine.getFineId());
+        assertNull(feeFine.getItemId());
+        assertNull(feeFine.getInstanceId());
+        assertNull(feeFine.getAmount());
         assertNull(feeFine.getFineDate());
         assertNull(feeFine.getItemTitle());
     }
@@ -48,6 +52,8 @@ public class FeeFineTest {
         final FeeFine feeFine = new FeeFine.FeeFineBuilder()
             .amount(1.0)
             .fineId("fineId")
+            .itemId("itemId")
+            .instanceId("instanceId")
             .fineType("fineType")
             .fineDate(now)
             .itemTitle("itemTitle")
@@ -58,6 +64,8 @@ public class FeeFineTest {
 
         assertEquals(1.0, feeFine.getAmount(), 0);
         assertEquals("fineId", feeFine.getFineId());
+        assertEquals("itemId", feeFine.getItemId());
+        assertEquals("instanceId", feeFine.getInstanceId());
         assertEquals("fineType", feeFine.getFineType());
         assertEquals(now.toString(), feeFine.getFineDate().toString());
         assertEquals("itemTitle", feeFine.getItemTitle());
@@ -67,10 +75,12 @@ public class FeeFineTest {
     public void testUpdate() {
         final Date now = new Date();
         final Date later = Date.from(now.toInstant().plusSeconds(100));
-        final FeeFine feeFine = new FeeFine(1.0, "fineId", "fineType", now, "itemTitle");
+        final FeeFine feeFine = new FeeFine("fineId", "itemId", "instanceId", 1.0, "fineType", now, "itemTitle");
 
-        feeFine.setAmount(2.0);
         feeFine.setFineId("updatedId");
+        feeFine.setItemId("updatedItemId");
+        feeFine.setInstanceId("updatedInstanceId");
+        feeFine.setAmount(2.0);
         feeFine.setFineType("updatedType");
         feeFine.setFineDate(later);
         feeFine.setItemTitle("updatedTitle");
@@ -78,8 +88,10 @@ public class FeeFineTest {
         assertNotNull(feeFine);
         assertNotNull(feeFine.getFineDate());
 
-        assertEquals(2.0, feeFine.getAmount(), 0);
         assertEquals("updatedId", feeFine.getFineId());
+        assertEquals("updatedItemId", feeFine.getItemId());
+        assertEquals("updatedInstanceId", feeFine.getInstanceId());
+        assertEquals(2.0, feeFine.getAmount(), 0);
         assertEquals("updatedType", feeFine.getFineType());
         assertEquals(later.toString(), feeFine.getFineDate().toString());
         assertEquals("updatedTitle", feeFine.getItemTitle());
@@ -88,8 +100,8 @@ public class FeeFineTest {
     @Test
     public void testEquals() {
         final Date now = new Date();
-        final FeeFine feeFine1 = new FeeFine(1.0, "fineId", "fineType", now, "itemTitle");
-        final FeeFine feeFine2 = new FeeFine(1.0, "fineId", "fineType", now, "itemTitle");
+        final FeeFine feeFine1 = new FeeFine("fineId", "itemId", "instanceId", 1.0, "fineType", now, "itemTitle");
+        final FeeFine feeFine2 = new FeeFine("fineId", "itemId", "instanceId", 1.0, "fineType", now, "itemTitle");
         final FeeFine feeFine3 = new FeeFine();
 
         assertTrue(feeFine1.equals(feeFine2));

--- a/domain/src/test/java/edu/tamu/catalog/domain/model/HoldRequestTest.java
+++ b/domain/src/test/java/edu/tamu/catalog/domain/model/HoldRequestTest.java
@@ -20,13 +20,14 @@ public class HoldRequestTest {
         final Date now = new Date();
         final Integer one = 1;
 
-        final HoldRequest holdRequest = new HoldRequest("requestId", "itemId", "requestType", "itemTitle", "statusText", "pickupServicePoint", one, now);
+        final HoldRequest holdRequest = new HoldRequest("requestId", "itemId", "instanceId", "requestType", "itemTitle", "statusText", "pickupServicePoint", one, now);
 
         assertNotNull(holdRequest);
         assertNotNull(holdRequest.getExpirationDate());
 
         assertEquals("requestId", holdRequest.getRequestId());
         assertEquals("itemId", holdRequest.getItemId());
+        assertEquals("instanceId", holdRequest.getInstanceId());
         assertEquals("requestType", holdRequest.getRequestType());
         assertEquals("itemTitle", holdRequest.getItemTitle());
         assertEquals("statusText", holdRequest.getStatusText());
@@ -43,6 +44,7 @@ public class HoldRequestTest {
 
         assertNull(holdRequest.getRequestId());
         assertNull(holdRequest.getItemId());
+        assertNull(holdRequest.getInstanceId());
         assertNull(holdRequest.getRequestType());
         assertNull(holdRequest.getItemTitle());
         assertNull(holdRequest.getStatusText());
@@ -58,6 +60,7 @@ public class HoldRequestTest {
         final HoldRequest holdRequest = new HoldRequest.HoldRequestBuilder()
             .requestId("requestId")
             .itemId("itemId")
+            .instanceId("instanceId")
             .requestType("requestType")
             .itemTitle("itemTitle")
             .statusText("statusText")
@@ -71,6 +74,7 @@ public class HoldRequestTest {
 
         assertEquals("requestId", holdRequest.getRequestId());
         assertEquals("itemId", holdRequest.getItemId());
+        assertEquals("instanceId", holdRequest.getInstanceId());
         assertEquals("requestType", holdRequest.getRequestType());
         assertEquals("itemTitle", holdRequest.getItemTitle());
         assertEquals("statusText", holdRequest.getStatusText());
@@ -86,10 +90,11 @@ public class HoldRequestTest {
         final Integer one = 1;
         final Integer two = 2;
 
-        final HoldRequest holdRequest = new HoldRequest("requestId", "itemId", "requestType", "itemTitle", "statusText", "pickupServicePoint", one, now);
+        final HoldRequest holdRequest = new HoldRequest("requestId", "itemId", "instanceId", "requestType", "itemTitle", "statusText", "pickupServicePoint", one, now);
 
         holdRequest.setRequestId("updatedRequestId");
         holdRequest.setItemId("updatedItemId");
+        holdRequest.setInstanceId("updatedInstanceId");
         holdRequest.setRequestType("updatedRequestType");
         holdRequest.setItemTitle("updatedItemTitle");
         holdRequest.setStatusText("updatedStatusText");
@@ -102,6 +107,7 @@ public class HoldRequestTest {
 
         assertEquals("updatedRequestId", holdRequest.getRequestId());
         assertEquals("updatedItemId", holdRequest.getItemId());
+        assertEquals("updatedInstanceId", holdRequest.getInstanceId());
         assertEquals("updatedRequestType", holdRequest.getRequestType());
         assertEquals("updatedItemTitle", holdRequest.getItemTitle());
         assertEquals("updatedStatusText", holdRequest.getStatusText());
@@ -115,8 +121,8 @@ public class HoldRequestTest {
         final Date now = new Date();
         final Integer one = 1;
 
-        final HoldRequest holdRequest1 = new HoldRequest("requestId", "itemId", "requestType", "itemTitle", "statusText", "pickupServicePoint", one, now);
-        final HoldRequest holdRequest2 = new HoldRequest("requestId", "itemId", "requestType", "itemTitle", "statusText", "pickupServicePoint", one, now);
+        final HoldRequest holdRequest1 = new HoldRequest("requestId", "itemId", "instanceId", "requestType", "itemTitle", "statusText", "pickupServicePoint", one, now);
+        final HoldRequest holdRequest2 = new HoldRequest("requestId", "itemId", "instanceId", "requestType", "itemTitle", "statusText", "pickupServicePoint", one, now);
         final HoldRequest holdRequest3 = new HoldRequest();
 
         assertTrue(holdRequest1.equals(holdRequest2));

--- a/domain/src/test/java/edu/tamu/catalog/domain/model/HoldingsRecordTest.java
+++ b/domain/src/test/java/edu/tamu/catalog/domain/model/HoldingsRecordTest.java
@@ -23,13 +23,14 @@ public class HoldingsRecordTest {
         catalogItem.put("key", "value");
         catalogItems.put("item", catalogItem);
 
-        final HoldingsRecord holdingsRecord = new HoldingsRecord("marcRecordLeader", "mfhd", "issn", "isbn", "title",
-            "author", "publisher", "place", "year", "genre", "fallbackLocationCode", "edition", "oclc", "recordId",
-            "callNumber", false, catalogItems);
+        final HoldingsRecord holdingsRecord = new HoldingsRecord("recordId", "marcRecordLeader", "mfhd", "issn",
+            "isbn", "title", "author", "publisher", "place", "year", "genre", "fallbackLocationCode", "edition",
+            "oclc", "callNumber", false, catalogItems);
 
         assertNotNull(holdingsRecord);
         assertNotNull(holdingsRecord.getCatalogItems());
 
+        assertEquals("recordId", holdingsRecord.getRecordId());
         assertEquals("marcRecordLeader", holdingsRecord.getMarcRecordLeader());
         assertEquals("mfhd", holdingsRecord.getMfhd());
         assertEquals("issn", holdingsRecord.getIssn());
@@ -43,7 +44,6 @@ public class HoldingsRecordTest {
         assertEquals("fallbackLocationCode", holdingsRecord.getFallbackLocationCode());
         assertEquals("edition", holdingsRecord.getEdition());
         assertEquals("oclc", holdingsRecord.getOclc());
-        assertEquals("recordId", holdingsRecord.getRecordId());
         assertEquals("callNumber", holdingsRecord.getCallNumber());
         assertEquals(false, holdingsRecord.isLargeVolume());
         assertEquals(1, holdingsRecord.getCatalogItems().size());
@@ -57,6 +57,7 @@ public class HoldingsRecordTest {
 
         assertNotNull(holdingsRecord);
 
+        assertNull(holdingsRecord.getRecordId());
         assertNull(holdingsRecord.getMarcRecordLeader());
         assertNull(holdingsRecord.getMfhd());
         assertNull(holdingsRecord.getIssn());
@@ -70,7 +71,6 @@ public class HoldingsRecordTest {
         assertNull(holdingsRecord.getFallbackLocationCode());
         assertNull(holdingsRecord.getEdition());
         assertNull(holdingsRecord.getOclc());
-        assertNull(holdingsRecord.getRecordId());
         assertNull(holdingsRecord.getCallNumber());
         assertFalse(holdingsRecord.isLargeVolume());
         assertNull(holdingsRecord.getCatalogItems());
@@ -84,6 +84,7 @@ public class HoldingsRecordTest {
         catalogItems.put("item", catalogItem);
 
         final HoldingsRecord holdingsRecord = new HoldingsRecord.HoldingsRecordBuilder()
+            .recordId("recordId")
             .marcRecordLeader("marcRecordLeader")
             .mfhd("mfhd")
             .issn("issn")
@@ -97,7 +98,6 @@ public class HoldingsRecordTest {
             .fallbackLocationCode("fallbackLocationCode")
             .edition("edition")
             .oclc("oclc")
-            .recordId("recordId")
             .callNumber("callNumber")
             .largeVolume(false)
             .catalogItems(catalogItems)
@@ -106,6 +106,7 @@ public class HoldingsRecordTest {
         assertNotNull(holdingsRecord);
         assertNotNull(holdingsRecord.getCatalogItems());
 
+        assertEquals("recordId", holdingsRecord.getRecordId());
         assertEquals("marcRecordLeader", holdingsRecord.getMarcRecordLeader());
         assertEquals("mfhd", holdingsRecord.getMfhd());
         assertEquals("issn", holdingsRecord.getIssn());
@@ -119,7 +120,6 @@ public class HoldingsRecordTest {
         assertEquals("fallbackLocationCode", holdingsRecord.getFallbackLocationCode());
         assertEquals("edition", holdingsRecord.getEdition());
         assertEquals("oclc", holdingsRecord.getOclc());
-        assertEquals("recordId", holdingsRecord.getRecordId());
         assertEquals("callNumber", holdingsRecord.getCallNumber());
         assertEquals(false, holdingsRecord.isLargeVolume());
         assertEquals(1, holdingsRecord.getCatalogItems().size());
@@ -142,10 +142,11 @@ public class HoldingsRecordTest {
         updatedCatalogItems.put("item1", catalogItem1);
         updatedCatalogItems.put("item2", catalogItem2);
 
-        final HoldingsRecord holdingsRecord = new HoldingsRecord("marcRecordLeader", "mfhd", "issn", "isbn", "title",
-            "author", "publisher", "place", "year", "genre", "fallbackLocationCode", "edition", "oclc", "recordId",
-            "callNumber", false, catalogItems);
+        final HoldingsRecord holdingsRecord = new HoldingsRecord("recordId", "marcRecordLeader", "mfhd", "issn",
+            "isbn", "title", "author", "publisher", "place", "year", "genre", "fallbackLocationCode", "edition",
+            "oclc", "callNumber", false, catalogItems);
 
+        holdingsRecord.setRecordId("updatedRecordId");
         holdingsRecord.setMarcRecordLeader("updatedMarcRecordLeader");
         holdingsRecord.setMfhd("updatedMfhd");
         holdingsRecord.setIssn("updatedIssn");
@@ -159,7 +160,6 @@ public class HoldingsRecordTest {
         holdingsRecord.setFallbackLocationCode("updatedFallbackLocationCode");
         holdingsRecord.setEdition("updatedEdition");
         holdingsRecord.setOclc("updatedOclc");
-        holdingsRecord.setRecordId("updatedRecordId");
         holdingsRecord.setCallNumber("updatedCallNumber");
         holdingsRecord.setLargeVolume(true);
         holdingsRecord.setCatalogItems(updatedCatalogItems);
@@ -167,6 +167,7 @@ public class HoldingsRecordTest {
         assertNotNull(holdingsRecord);
         assertNotNull(holdingsRecord.getCatalogItems());
 
+        assertEquals("updatedRecordId", holdingsRecord.getRecordId());
         assertEquals("updatedMarcRecordLeader", holdingsRecord.getMarcRecordLeader());
         assertEquals("updatedMfhd", holdingsRecord.getMfhd());
         assertEquals("updatedIssn", holdingsRecord.getIssn());
@@ -180,7 +181,6 @@ public class HoldingsRecordTest {
         assertEquals("updatedFallbackLocationCode", holdingsRecord.getFallbackLocationCode());
         assertEquals("updatedEdition", holdingsRecord.getEdition());
         assertEquals("updatedOclc", holdingsRecord.getOclc());
-        assertEquals("updatedRecordId", holdingsRecord.getRecordId());
         assertEquals("updatedCallNumber", holdingsRecord.getCallNumber());
         assertEquals(true, holdingsRecord.isLargeVolume());
         assertEquals(2, holdingsRecord.getCatalogItems().size());
@@ -195,13 +195,13 @@ public class HoldingsRecordTest {
         catalogItem.put("key", "value");
         catalogItems.put("item", catalogItem);
 
-        final HoldingsRecord holdingsRecord1 = new HoldingsRecord("marcRecordLeader", "mfhd", "issn", "isbn", "title",
-            "author", "publisher", "place", "year", "genre", "fallbackLocationCode", "edition", "oclc", "recordId",
-            "callNumber", catalogItems);
+        final HoldingsRecord holdingsRecord1 = new HoldingsRecord("recordId", "marcRecordLeader", "mfhd", "issn",
+            "isbn", "title", "author", "publisher", "place", "year", "genre", "fallbackLocationCode", "edition",
+            "oclc", "callNumber", catalogItems);
 
-        final HoldingsRecord holdingsRecord2 = new HoldingsRecord("marcRecordLeader", "mfhd", "issn", "isbn", "title",
-            "author", "publisher", "place", "year", "genre", "fallbackLocationCode", "edition", "oclc", "recordId",
-            "callNumber", false, catalogItems);
+        final HoldingsRecord holdingsRecord2 = new HoldingsRecord("recordId", "marcRecordLeader", "mfhd", "issn",
+            "isbn", "title", "author", "publisher", "place", "year", "genre", "fallbackLocationCode", "edition",
+            "oclc", "callNumber", false, catalogItems);
 
         final HoldingsRecord holdingsRecord3 = new HoldingsRecord();
 

--- a/service/src/main/java/edu/tamu/catalog/model/FolioHoldCancellation.java
+++ b/service/src/main/java/edu/tamu/catalog/model/FolioHoldCancellation.java
@@ -4,12 +4,23 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * An implementation of the edge-patron cancellation request body json.
+ *
+ * Notes:
+ *   edge-patron uses "holdId" instead of "requestId" for the cancellation request body json.
+ *   edge-patron uses a single 'l' for 'canceledByUserId' and 'canceledDate'.
+ *   edge-patron uses a double 'l' for 'cancellationReasonId' and 'cancellationAdditionalInformation'.
+ *
+ * @see https://github.com/folio-org/edge-patron/blob/master/src/main/java/org/folio/edge/patron/model/HoldCancellation.java
+ * @see https://github.com/folio-org/edge-patron/blob/master/ramls/examples/hold-cancellation.json
+ */
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
 public class FolioHoldCancellation {
 
-    private String requestId;
+    private String holdId;
 
     private String cancellationReasonId;
 

--- a/service/src/main/java/edu/tamu/catalog/model/FolioHoldCancellation.java
+++ b/service/src/main/java/edu/tamu/catalog/model/FolioHoldCancellation.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Data
 public class FolioHoldCancellation {
 
-    private String holdId;
+    private String requestId;
 
     private String cancellationReasonId;
 

--- a/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
+++ b/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
@@ -236,8 +236,9 @@ public class FolioCatalogService implements CatalogService {
 
         logger.debug("Cancelling hold request via: {}", url);
 
+        // edge-patron uses "holdId" instead of "requestId" for the cancellation request body json.
         FolioHoldCancellation folioCancellation = new FolioHoldCancellation();
-        folioCancellation.setRequestId(requestId);
+        folioCancellation.setHoldId(requestId);
         folioCancellation.setCancellationReasonId(properties.getCancelHoldReasonId());
         folioCancellation.setCanceledDate(FolioDateTime.convert(new Date()));
 

--- a/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
+++ b/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
@@ -147,6 +147,8 @@ public class FolioCatalogService implements CatalogService {
                 JsonNode charge = iter.next();
                 list.add(FeeFine.builder()
                     .fineId(getText(charge, "/feeFineId"))
+                    .itemId(getText(charge, "/item/itemId"))
+                    .instanceId(getText(charge, "/item/instanceId"))
                     .fineType(getText(charge, "/reason"))
                     .fineDate(getDate(charge, "/accrualDate"))
                     .itemTitle(getText(charge, "/item/title"))
@@ -210,12 +212,13 @@ public class FolioCatalogService implements CatalogService {
                 String requestId = getText(hold, "/requestId");
                 String servicePointId = getText(hold, "/pickupLocationId");
                 list.add(HoldRequest.builder()
+                    .requestId(requestId)
                     .itemId(getText(hold, "/item/itemId"))
+                    .instanceId(getText(hold, "/item/instanceId"))
                     .itemTitle(getText(hold, "/item/title"))
                     .statusText(getText(hold, "/status"))
                     .queuePosition(getInt(hold, "/queuePosition"))
                     .expirationDate(getDate(hold, "/expirationDate"))
-                    .requestId(requestId)
                     .requestType(getRequestType(requestId))
                     .pickupServicePoint(getServicePointDisplayName(servicePointId))
                     .build());
@@ -224,8 +227,6 @@ public class FolioCatalogService implements CatalogService {
 
         return list;
     }
-
-    
 
     @Override
     public void cancelHoldRequest(String uin, String requestId) throws Exception {
@@ -236,7 +237,7 @@ public class FolioCatalogService implements CatalogService {
         logger.debug("Cancelling hold request via: {}", url);
 
         FolioHoldCancellation folioCancellation = new FolioHoldCancellation();
-        folioCancellation.setHoldId(requestId);
+        folioCancellation.setRequestId(requestId);
         folioCancellation.setCancellationReasonId(properties.getCancelHoldReasonId());
         folioCancellation.setCanceledDate(FolioDateTime.convert(new Date()));
 
@@ -599,11 +600,11 @@ public class FolioCatalogService implements CatalogService {
     private LoanItem buildLoanItem(JsonNode loan) throws Exception {
         return LoanItem.builder()
             .loanId(getText(loan, "/id"))
+            .itemId(getText(loan, "/item/itemId"))
+            .instanceId(getText(loan, "/item/instanceId"))
             .loanDate(getDate(loan, "/loanDate"))
             .loanDueDate(getDate(loan, "/dueDate"))
             .overdue(getBoolean(loan, "/overdue", false))
-            .itemId(getText(loan, "/item/itemId"))
-            .instanceId(getText(loan, "/item/instanceId"))
             .title(getText(loan, "/item/title"))
             .author(getText(loan, "/item/author"))
             .build();

--- a/service/src/test/java/edu/tamu/catalog/controller/PatronControllerTest.java
+++ b/service/src/test/java/edu/tamu/catalog/controller/PatronControllerTest.java
@@ -123,11 +123,13 @@ public class PatronControllerTest extends AbstractTestRestController {
         );
 
         ResponseFieldsSnippet responseFields = responseFields(
-            fieldWithPath("[].amount").description("The title of the item associated with the fine."),
-            fieldWithPath("[].fineId").description("The UUID associated with the fine."),
-            fieldWithPath("[].fineType").description("The type of the fine."),
-            fieldWithPath("[].fineDate").description("A timestamp in milliseconds from UNIX epoch representing the date the fine was accrued."),
-            fieldWithPath("[].itemTitle").description("The title of the item associated with the fine.")
+            fieldWithPath("[].fineId").description("The Fine UUID."),
+            fieldWithPath("[].itemId").description("The Item UUID."),
+            fieldWithPath("[].instanceId").description("The Instance UUID."),
+            fieldWithPath("[].amount").description("The title of the Item associated with the fine."),
+            fieldWithPath("[].fineType").description("The type of the Fine."),
+            fieldWithPath("[].fineDate").description("A timestamp in milliseconds from UNIX epoch representing the date the Fine was accrued."),
+            fieldWithPath("[].itemTitle").description("The title of the Item associated with the Fine.")
         );
 
         performPatronGetWithMockMVC(getFinesUrl(), FINES_ENDPOINT, pathParameters,
@@ -145,14 +147,14 @@ public class PatronControllerTest extends AbstractTestRestController {
         );
 
         ResponseFieldsSnippet responseFields = responseFields(
-            fieldWithPath("[].loanId").description("The loan id."),
-            fieldWithPath("[].itemId").description("The item id."),
-            fieldWithPath("[].instanceId").description("The instance id."),
-            fieldWithPath("[].loanDate").description("The loan date."),
-            fieldWithPath("[].loanDueDate").description("The loan due date."),
-            fieldWithPath("[].overdue").description("Is the loan overdue."),
-            fieldWithPath("[].title").description("The title of the loan item."),
-            fieldWithPath("[].author").description("The author of the loan item.")
+            fieldWithPath("[].loanId").description("The Loan UUID."),
+            fieldWithPath("[].itemId").description("The Item UUID."),
+            fieldWithPath("[].instanceId").description("The Instance UUID."),
+            fieldWithPath("[].loanDate").description("The Loan date."),
+            fieldWithPath("[].loanDueDate").description("The Loan due date."),
+            fieldWithPath("[].overdue").description("Is the Loan overdue."),
+            fieldWithPath("[].title").description("The title of the Loan Item."),
+            fieldWithPath("[].author").description("The author of the Loan Item.")
         );
 
         performPatronGetWithMockMVC(getLoansUrl(), LOANS_ENDPOINT, pathParameters, requestParameters,
@@ -165,7 +167,7 @@ public class PatronControllerTest extends AbstractTestRestController {
     public void testLoanItemRenewalMockMVC() throws Exception {
         PathParametersSnippet pathParameters = pathParameters(
             parameterWithName(UIN_FIELD).description("The patron UIN."),
-            parameterWithName("itemId").description("The UUID of the loan item.")
+            parameterWithName("itemId").description("The UUID of the Loan Item.")
         );
 
         RequestParametersSnippet requestParameters = requestParameters(
@@ -173,14 +175,14 @@ public class PatronControllerTest extends AbstractTestRestController {
         );
 
         ResponseFieldsSnippet responseFields = responseFields(
-            fieldWithPath("loanId").description("The loan id."),
-            fieldWithPath("itemId").description("The item id."),
-            fieldWithPath("instanceId").description("The instance id."),
-            fieldWithPath("loanDate").description("The loan date."),
-            fieldWithPath("loanDueDate").description("The loan due date."),
-            fieldWithPath("overdue").description("Is the loan overdue."),
-            fieldWithPath("title").description("The title of the loan item."),
-            fieldWithPath("author").description("The author of the loan item.")
+            fieldWithPath("loanId").description("The Loan UUID."),
+            fieldWithPath("itemId").description("The Item UUID."),
+            fieldWithPath("instanceId").description("The Instance UUID."),
+            fieldWithPath("loanDate").description("The Loan date."),
+            fieldWithPath("loanDueDate").description("The Loan due date."),
+            fieldWithPath("overdue").description("Is the Loan overdue."),
+            fieldWithPath("title").description("The title of the Loan Item."),
+            fieldWithPath("author").description("The author of the Loan Item.")
         );
 
         expectPostResponse(getLoanItemRenewalUrl(), once(), respondJsonOk(patronAccountRenewalResource));
@@ -216,11 +218,12 @@ public class PatronControllerTest extends AbstractTestRestController {
         );
 
         ResponseFieldsSnippet responseFields = responseFields(
-            fieldWithPath("[].requestId").description("The UUID of the hold request."),
-            fieldWithPath("[].itemId").description("The UUID of the item associated with the hold request."),
-            fieldWithPath("[].requestType").description("The type of the hold request."),
-            fieldWithPath("[].itemTitle").description("The title of the item associated with the fine."),
-            fieldWithPath("[].statusText").description("A descriptive status of the hold request."),
+            fieldWithPath("[].requestId").description("The Hold Request UUID."),
+            fieldWithPath("[].itemId").description("The Item UUID."),
+            fieldWithPath("[].instanceId").description("The Instance UUID."),
+            fieldWithPath("[].requestType").description("The type of the Hold Request."),
+            fieldWithPath("[].itemTitle").description("The title of the Item associated with the Hold Request."),
+            fieldWithPath("[].statusText").description("A descriptive status of the Hold Request."),
             fieldWithPath("[].pickupServicePoint").description("A title describing the pickup service point location."),
             fieldWithPath("[].queuePosition").description("The position within the queue."),
             fieldWithPath("[].expirationDate").description("A timestamp in milliseconds from UNIX epoch representing the date the hold request will expire.")

--- a/service/src/test/resources/mock/response/catalog/fines.json
+++ b/service/src/test/resources/mock/response/catalog/fines.json
@@ -1,14 +1,18 @@
 [
   {
-    "amount": 1,
     "fineId": "d4d849f9-f953-4f7c-acf6-b16b65cb3bb4",
+    "itemId": "0b82a7d0-a681-39d9-8b11-5b09726722d9",
+    "instanceId": "bd173687-8355-3018-b2bc-eb3bfd14c869",
+    "amount": 1,
     "fineType": "Overdue (migrated-do not use)",
     "fineDate": 1556719726000,
     "itemTitle": "Guardians of the galaxy / Marvel Studios ; co-producers, David J. Grant, Jonathan Schwartz ; executive producers, Nik Korda, Stan Lee, Victoria Alonso, Jeremy Latcham, Alan Fine, Louis D'Esposito ; produced by Kevin Feige ; written by James Gunn and Nicole Perlman ; directed by James Gunn."
   },
   {
-    "amount": 1,
     "fineId": "e2791487-9962-4e67-98dd-99f8bc89e3e4",
+    "itemId": "13c4044e-9ecc-3c90-93df-4a58d6e0f597",
+    "instanceId": "d42f4d83-a5ab-38f4-b396-1a43a471b86f",
+    "amount": 1,
     "fineType": "Overdue (migrated-do not use)",
     "fineDate": 1566308501000,
     "itemTitle": "Bill & Ted's excellent adventure / an Orion Pictures release ; Nelson Entertainment presents an Interscope Communications production ; in association with Soisson/Murphey Productions ;  written by Chris Matheson & Ed Solomon ; produced by Scott Kroopf, Michael S. Murphey, Joel Soisson ; directed by Stephen Herek."

--- a/service/src/test/resources/mock/response/catalog/requests.json
+++ b/service/src/test/resources/mock/response/catalog/requests.json
@@ -2,6 +2,7 @@
   {
     "requestId": "8bbac557-d66f-4571-bbbf-47a107cc1589",
     "itemId": "26670295-716a-4f84-8f65-2ef31707c017",
+    "instanceId": "255f82f3-5b1b-4239-93e4-ec6acf03ad9d",
     "requestType": "Recall",
     "itemTitle": "I Want to Hold Your Hand",
     "statusText": "Open - Not yet filled",


### PR DESCRIPTION
The `itemId` is required by clients and needs to be made available.

Organize the Domain Models to have all of the "id" fields at the top.
This should make them easier to find and is hopefully a little bit more organized.
The original approach was to closely match the legacy structure as possible, which led to different locations of where the ID fields are presented.

`instanceId` is being included for consistency.
That is, we should either consistently have `instanceId` or not have it at all.
If it is decided we do not want `instanceId` on the Domain Model, then it can be removed, likely with little harm.

~I also noticed and corrected where `holdId` was used when `requestId` is more consistent and hopefully less confusing.~
[It seems `holdId` is correct due, in this specific case.](https://github.com/folio-org/edge-patron/blob/65370b9d5cef92f4d678092ee87cb95a1c2fe98d/src/main/java/org/folio/edge/patron/model/HoldCancellation.java#L18)

resolves #125 