### PR TITLE
[156] Map FOLIO chronology field to chron

### DIFF
--- a/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
+++ b/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
@@ -785,6 +785,7 @@ public class FolioCatalogService implements CatalogService {
                 itemData.put("barcode", i.at("/barcode").asText());
                 itemData.put("locationCode", getLocation(i.at("/effectiveLocationId").asText()).at("/code").asText());
                 itemData.put("enumeration", i.at("/enumeration").asText());
+                itemData.put("chron", i.at("/chronology").asText());
                 itemData.put("status", i.at("/status/name").asText());
                 itemData.put("typeDesc", loanType.at("/name").asText());
                 okapiItems.put(i.at("/hrid").asText(), itemData);


### PR DESCRIPTION
Resolves #156 

The GIFM Service expects a multi-item holding to have volume/issue details for each item in a Catalog Service HoldingsRecord, either in the 'enumeration' field or 'chron' field, depending on the type of record.

This PR populates the 'chron' field for FOLIO integration from the source 'chronology' field. 

'enumeration' was previously added.