### PR TITLE
Fix call number inclusion for Folio integration and add holding location to HoldingsRecord

### DIFF
--- a/domain/src/main/java/edu/tamu/catalog/domain/model/HoldingsRecord.java
+++ b/domain/src/main/java/edu/tamu/catalog/domain/model/HoldingsRecord.java
@@ -45,6 +45,8 @@ public class HoldingsRecord {
 
     private boolean largeVolume;
 
+    private String holdingLocation;
+
     private Map<String, Map<String, String>> catalogItems;
 
     public boolean isMultiVolume() {

--- a/domain/src/main/java/edu/tamu/catalog/domain/model/HoldingsRecord.java
+++ b/domain/src/main/java/edu/tamu/catalog/domain/model/HoldingsRecord.java
@@ -43,9 +43,9 @@ public class HoldingsRecord {
 
     private String callNumber;
 
-    private boolean largeVolume;
-
     private String holdingLocation;
+
+    private boolean largeVolume;
 
     private Map<String, Map<String, String>> catalogItems;
 

--- a/domain/src/test/java/edu/tamu/catalog/domain/model/HoldingsRecordTest.java
+++ b/domain/src/test/java/edu/tamu/catalog/domain/model/HoldingsRecordTest.java
@@ -25,7 +25,7 @@ public class HoldingsRecordTest {
 
         final HoldingsRecord holdingsRecord = new HoldingsRecord("marcRecordLeader", "mfhd", "issn",
             "isbn", "title", "author", "publisher", "place", "year", "genre", "fallbackLocationCode", "edition",
-            "oclc", "recordId", "callNumber", false, catalogItems);
+            "oclc", "recordId", "callNumber", "holdingLocation", false, catalogItems);
 
         assertNotNull(holdingsRecord);
         assertNotNull(holdingsRecord.getCatalogItems());
@@ -45,6 +45,7 @@ public class HoldingsRecordTest {
         assertEquals("edition", holdingsRecord.getEdition());
         assertEquals("oclc", holdingsRecord.getOclc());
         assertEquals("callNumber", holdingsRecord.getCallNumber());
+        assertEquals("holdingLocation", holdingsRecord.getHoldingLocation());
         assertEquals(false, holdingsRecord.isLargeVolume());
         assertEquals(1, holdingsRecord.getCatalogItems().size());
 
@@ -99,6 +100,7 @@ public class HoldingsRecordTest {
             .edition("edition")
             .oclc("oclc")
             .callNumber("callNumber")
+            .holdingLocation("holdingLocation")
             .largeVolume(false)
             .catalogItems(catalogItems)
             .build();
@@ -121,6 +123,7 @@ public class HoldingsRecordTest {
         assertEquals("edition", holdingsRecord.getEdition());
         assertEquals("oclc", holdingsRecord.getOclc());
         assertEquals("callNumber", holdingsRecord.getCallNumber());
+        assertEquals("holdingLocation", holdingsRecord.getHoldingLocation());
         assertEquals(false, holdingsRecord.isLargeVolume());
         assertEquals(1, holdingsRecord.getCatalogItems().size());
 
@@ -144,7 +147,7 @@ public class HoldingsRecordTest {
 
         final HoldingsRecord holdingsRecord = new HoldingsRecord("recordId", "marcRecordLeader", "mfhd", "issn",
             "isbn", "title", "author", "publisher", "place", "year", "genre", "fallbackLocationCode", "edition",
-            "oclc", "callNumber", false, catalogItems);
+            "oclc", "callNumber", "holdingLocation", false, catalogItems);
 
         holdingsRecord.setRecordId("updatedRecordId");
         holdingsRecord.setMarcRecordLeader("updatedMarcRecordLeader");
@@ -161,6 +164,7 @@ public class HoldingsRecordTest {
         holdingsRecord.setEdition("updatedEdition");
         holdingsRecord.setOclc("updatedOclc");
         holdingsRecord.setCallNumber("updatedCallNumber");
+        holdingsRecord.setHoldingLocation("updatedHoldingLocation");
         holdingsRecord.setLargeVolume(true);
         holdingsRecord.setCatalogItems(updatedCatalogItems);
 
@@ -182,6 +186,7 @@ public class HoldingsRecordTest {
         assertEquals("updatedEdition", holdingsRecord.getEdition());
         assertEquals("updatedOclc", holdingsRecord.getOclc());
         assertEquals("updatedCallNumber", holdingsRecord.getCallNumber());
+        assertEquals("updatedHoldingLocation", holdingsRecord.getHoldingLocation());
         assertEquals(true, holdingsRecord.isLargeVolume());
         assertEquals(2, holdingsRecord.getCatalogItems().size());
 
@@ -211,13 +216,14 @@ public class HoldingsRecordTest {
             .edition("edition")
             .oclc("oclc")
             .callNumber("callNumber")
+            .holdingLocation("holdingLocation")
             .largeVolume(false)
             .catalogItems(catalogItems)
             .build();
 
         final HoldingsRecord holdingsRecord2 = new HoldingsRecord("marcRecordLeader", "mfhd", "issn",
             "isbn", "title", "author", "publisher", "place", "year", "genre", "fallbackLocationCode", "edition",
-            "oclc", "recordId", "callNumber", false, catalogItems);
+            "oclc", "recordId", "callNumber", "holdingLocation", false, catalogItems);
 
         final HoldingsRecord holdingsRecord3 = new HoldingsRecord();
 

--- a/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
+++ b/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
@@ -696,6 +696,7 @@ public class FolioCatalogService implements CatalogService {
                 JsonNode holdingLocationNode = getLocation(holding.at("/permanentLocationId").asText());
                 String fallbackLocationCode = holdingLocationNode.at("/code").asText();
                 String holdingLocationName = holdingLocationNode.at("/name").asText();
+                String holdingCallNumber = holding.at("/callNumber").asText();
                 //get items for holding from okapi
                 Map<String, Map<String,String>> okapiItems = getOkapiItems(holding.at("/id").asText());
 
@@ -718,7 +719,7 @@ public class FolioCatalogService implements CatalogService {
                                 .edition(recordValues.getEdition())
                                 .oclc(recordValues.getOclc())
                                 .recordId(recordValues.getRecordId())
-                                .callNumber(holding.at("/callNumber").asText())
+                                .callNumber(holdingCallNumber)
                                 .largeVolume(recordValues.isLargeVolume())
                                 .catalogItems(okapiItems.size() > 0 ? okapiItems:recordValues.getCatalogItems())
                                 .build();
@@ -730,7 +731,7 @@ public class FolioCatalogService implements CatalogService {
                 logger.debug("MFHD: {}", currentHolding.getMfhd());
                 logger.debug("ISBN: {}", currentHolding.getIsbn());
                 logger.debug("Fallback location: {}", currentHolding.getFallbackLocationCode());
-                logger.debug("Call number: {}", currentHolding.getCallNumber());
+                logger.debug("Call number: {}", holdingCallNumber);
                 logger.debug("Valid large volume: {}", currentHolding.isLargeVolume());
             });
 
@@ -792,7 +793,7 @@ public class FolioCatalogService implements CatalogService {
                 itemData.put("chron", i.at("/chronology").asText());
                 itemData.put("status", i.at("/status/name").asText());
                 itemData.put("typeDesc", loanType.at("/name").asText());
-                itemData.put("callNumber", i.at("/effectiveCallNumberComponents").at("/callNumber").asText());
+                itemData.put("callNumber", i.at("/effectiveCallNumberComponents/callNumber").asText());
                 okapiItems.put(i.at("/hrid").asText(), itemData);
             });
         }

--- a/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
+++ b/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
@@ -787,7 +787,7 @@ public class FolioCatalogService implements CatalogService {
                 itemData.put("hrid", i.at("/hrid").asText());
                 itemData.put("barcode", i.at("/barcode").asText());
                 itemData.put("locationCode", itemLocationNode.at("/code").asText());
-                itemData.put("locationName", itemLocationNode.at("/name").asText());
+                itemData.put("location", itemLocationNode.at("/name").asText());
                 itemData.put("enumeration", i.at("/enumeration").asText());
                 itemData.put("chron", i.at("/chronology").asText());
                 itemData.put("status", i.at("/status/name").asText());
@@ -869,13 +869,11 @@ public class FolioCatalogService implements CatalogService {
         // TODO: the current implementation of buildCoreHolding() expects a slightly
         // different nesting structure in the XML.
         Map<String, String> holdingValues = Marc21Xml.buildCoreHolding(NODE_PREFIX, marcRecord);
-
         Map<String, Map<String, String>> catalogItems = new HashMap<String, Map<String, String>>();
 
         for (int i = 0; i < marcListCount; i++) {
             if (nodeNameMatches(marcList.item(i).getNodeName().toString(), NODE_DATA_FIELD) &&
                 Marc21Xml.attributeTagMatches(marcList.item(i), "952")) {
-
                 NodeList childNodes = marcList.item(i).getChildNodes();
                 for (int j = 0; j < childNodes.getLength(); j++) {
                     if (Marc21Xml.attributeCodeMatches(childNodes.item(j), "e")) {

--- a/service/src/main/java/edu/tamu/catalog/service/VoyagerCatalogService.java
+++ b/service/src/main/java/edu/tamu/catalog/service/VoyagerCatalogService.java
@@ -180,6 +180,7 @@ public class VoyagerCatalogService implements CatalogService {
                     .edition(recordValues.get(RECORD_EDITION))
                     .oclc(recordValues.get(RECORD_OCLC))
                     .callNumber(holdingValues.get(RECORD_CALL_NUMBER))
+                    .holdingLocation(holdingValues.get(RECORD_FALLBACK_LOCATION_CODE))
                     .largeVolume(validLargeVolume)
                     .catalogItems(catalogItems)
                     .build();
@@ -245,7 +246,7 @@ public class VoyagerCatalogService implements CatalogService {
                 recordValues.get(RECORD_AUTHOR), recordValues.get(RECORD_PUBLISHER), recordValues.get(RECORD_PLACE),
                 recordValues.get(RECORD_YEAR), recordValues.get(RECORD_GENRE), recordValues.get(RECORD_EDITION),
                 holdingValues.get(RECORD_FALLBACK_LOCATION_CODE), recordValues.get(RECORD_OCLC),
-                recordValues.get(RECORD_RECORD_ID), holdingValues.get(RECORD_CALL_NUMBER),
+                recordValues.get(RECORD_RECORD_ID), holdingValues.get(RECORD_CALL_NUMBER), holdingValues.get(RECORD_FALLBACK_LOCATION_CODE),
                 Boolean.valueOf(holdingValues.get(RECORD_VALID_LARGE_VOLUME)),
                 new HashMap<String, Map<String, String>>(catalogItems));
 


### PR DESCRIPTION
- Switches FolioCatalogService to get the call number from the holding because stock mod-oai-pmh does not provide it.
- FolioCatalogService: Adds human readable 'location' info to items
- Adds holdingLocation to the HoldingsRecord.
