### PR TITLE
Increase FOLIO item limit to 2000

### DIFF
--- a/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
+++ b/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
@@ -775,7 +775,7 @@ public class FolioCatalogService implements CatalogService {
         String itemsMessage = String.format("items from okapi with holdingsRecordId \"%s\"", holdingsRecordId);
 
         String itemsOffset = "0";
-        String itemsLimit = "1000";
+        String itemsLimit = "2000";
 
         logger.debug("Asking for items from: {}", itemsUrl);
         JsonNode itemsResponse = okapiRequestJsonNode(itemsUrl, HttpMethod.GET, itemsMessage, itemsQuery, itemsOffset, itemsLimit);


### PR DESCRIPTION
GIFM Service isn't able to provide complete buttons for holdings with more than 1000 items because the Catalog Service is only requesting the first 1000 items.

Customer has specified 2000 as a more appropriate limit.