### PR TITLE
Add call number prefix to HoldingsRecord

### DIFF
--- a/domain/src/main/java/edu/tamu/catalog/domain/model/HoldingsRecord.java
+++ b/domain/src/main/java/edu/tamu/catalog/domain/model/HoldingsRecord.java
@@ -44,6 +44,8 @@ public class HoldingsRecord {
 
     private String callNumber;
 
+    private String callNumberPrefix;
+
     private String holdingLocation;
 
     private List<Note> holdingNotes;

--- a/domain/src/test/java/edu/tamu/catalog/domain/model/HoldingsRecordTest.java
+++ b/domain/src/test/java/edu/tamu/catalog/domain/model/HoldingsRecordTest.java
@@ -26,7 +26,7 @@ public class HoldingsRecordTest {
 
         final HoldingsRecord holdingsRecord = new HoldingsRecord("marcRecordLeader", "mfhd", "issn",
             "isbn", "title", "author", "publisher", "place", "year", "genre", "fallbackLocationCode", "edition",
-            "oclc", "recordId", "callNumber", "holdingLocation", new ArrayList<Note>(), new ArrayList<String>(), false, catalogItems);
+            "oclc", "recordId", "callNumber", "callNumberPrefix", "holdingLocation", new ArrayList<Note>(), new ArrayList<String>(), false, catalogItems);
 
         assertNotNull(holdingsRecord);
         assertNotNull(holdingsRecord.getCatalogItems());
@@ -46,6 +46,7 @@ public class HoldingsRecordTest {
         assertEquals("edition", holdingsRecord.getEdition());
         assertEquals("oclc", holdingsRecord.getOclc());
         assertEquals("callNumber", holdingsRecord.getCallNumber());
+        assertEquals("callNumberPrefix", holdingsRecord.getCallNumberPrefix());
         assertEquals("holdingLocation", holdingsRecord.getHoldingLocation());
         assertEquals(false, holdingsRecord.isLargeVolume());
         assertEquals(1, holdingsRecord.getCatalogItems().size());
@@ -101,6 +102,7 @@ public class HoldingsRecordTest {
             .edition("edition")
             .oclc("oclc")
             .callNumber("callNumber")
+            .callNumberPrefix("callNumberPrefix")
             .holdingLocation("holdingLocation")
             .largeVolume(false)
             .catalogItems(catalogItems)
@@ -124,6 +126,7 @@ public class HoldingsRecordTest {
         assertEquals("edition", holdingsRecord.getEdition());
         assertEquals("oclc", holdingsRecord.getOclc());
         assertEquals("callNumber", holdingsRecord.getCallNumber());
+        assertEquals("callNumberPrefix", holdingsRecord.getCallNumberPrefix());
         assertEquals("holdingLocation", holdingsRecord.getHoldingLocation());
         assertEquals(false, holdingsRecord.isLargeVolume());
         assertEquals(1, holdingsRecord.getCatalogItems().size());
@@ -148,7 +151,7 @@ public class HoldingsRecordTest {
 
         final HoldingsRecord holdingsRecord = new HoldingsRecord("recordId", "marcRecordLeader", "mfhd", "issn",
             "isbn", "title", "author", "publisher", "place", "year", "genre", "fallbackLocationCode", "edition",
-            "oclc", "callNumber", "holdingLocation", new ArrayList<Note>(), new ArrayList<String>(), false, catalogItems);
+            "oclc", "callNumber", "callNumberPrefix", "holdingLocation", new ArrayList<Note>(), new ArrayList<String>(), false, catalogItems);
 
         holdingsRecord.setRecordId("updatedRecordId");
         holdingsRecord.setMarcRecordLeader("updatedMarcRecordLeader");
@@ -165,6 +168,7 @@ public class HoldingsRecordTest {
         holdingsRecord.setEdition("updatedEdition");
         holdingsRecord.setOclc("updatedOclc");
         holdingsRecord.setCallNumber("updatedCallNumber");
+        holdingsRecord.setCallNumberPrefix("updatedCallNumberPrefix");
         holdingsRecord.setHoldingLocation("updatedHoldingLocation");
         holdingsRecord.setLargeVolume(true);
         holdingsRecord.setCatalogItems(updatedCatalogItems);
@@ -187,6 +191,7 @@ public class HoldingsRecordTest {
         assertEquals("updatedEdition", holdingsRecord.getEdition());
         assertEquals("updatedOclc", holdingsRecord.getOclc());
         assertEquals("updatedCallNumber", holdingsRecord.getCallNumber());
+        assertEquals("updatedCallNumberPrefix", holdingsRecord.getCallNumberPrefix());
         assertEquals("updatedHoldingLocation", holdingsRecord.getHoldingLocation());
         assertEquals(true, holdingsRecord.isLargeVolume());
         assertEquals(2, holdingsRecord.getCatalogItems().size());
@@ -217,6 +222,7 @@ public class HoldingsRecordTest {
             .edition("edition")
             .oclc("oclc")
             .callNumber("callNumber")
+            .callNumberPrefix("callNumberPrefix")
             .holdingLocation("holdingLocation")
             .holdingNotes(new ArrayList<Note>())
             .holdingStatements(new ArrayList<String>())
@@ -226,7 +232,7 @@ public class HoldingsRecordTest {
 
         final HoldingsRecord holdingsRecord2 = new HoldingsRecord("marcRecordLeader", "mfhd", "issn",
             "isbn", "title", "author", "publisher", "place", "year", "genre", "fallbackLocationCode", "edition",
-            "oclc", "recordId", "callNumber", "holdingLocation", new ArrayList<Note>(), new ArrayList<String>(), false, catalogItems);
+            "oclc", "recordId", "callNumber", "callNumberPrefix", "holdingLocation", new ArrayList<Note>(), new ArrayList<String>(), false, catalogItems);
 
         final HoldingsRecord holdingsRecord3 = new HoldingsRecord();
 

--- a/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
+++ b/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
@@ -721,6 +721,7 @@ public class FolioCatalogService implements CatalogService {
                 String fallbackLocationCode = holdingLocationNode.at("/code").asText();
                 String holdingLocationName = holdingLocationNode.at("/discoveryDisplayName").asText();
                 String holdingCallNumber = holding.at("/callNumber").asText();
+                String holdingCallNumberPrefix = holding.at("/callNumberPrefix").asText();
 
                 List<Note> holdingNotes = new ArrayList<Note>();
                 holding.at("/notes").forEach(note -> {
@@ -764,6 +765,7 @@ public class FolioCatalogService implements CatalogService {
                                 .oclc(recordValues.getOclc())
                                 .recordId(recordValues.getRecordId())
                                 .callNumber(holdingCallNumber)
+                                .callNumberPrefix(holdingCallNumberPrefix)
                                 .largeVolume(recordValues.isLargeVolume())
                                 .catalogItems(okapiItems.size() > 0 ? okapiItems:recordValues.getCatalogItems())
                                 .holdingNotes(holdingNotes)
@@ -777,7 +779,7 @@ public class FolioCatalogService implements CatalogService {
                 logger.debug("MFHD: {}", currentHolding.getMfhd());
                 logger.debug("ISBN: {}", currentHolding.getIsbn());
                 logger.debug("Fallback location: {}", currentHolding.getFallbackLocationCode());
-                logger.debug("Call number: {}", holdingCallNumber);
+                logger.debug("Call number: {} {}", holdingCallNumberPrefix, holdingCallNumber);
                 logger.debug("Valid large volume: {}", currentHolding.isLargeVolume());
             });
 
@@ -840,6 +842,7 @@ public class FolioCatalogService implements CatalogService {
                 itemData.put("status", i.at("/status/name").asText());
                 itemData.put("typeDesc", loanType.at("/name").asText());
                 itemData.put("callNumber", i.at("/effectiveCallNumberComponents/callNumber").asText());
+                itemData.put("callNumberPrefix", i.at("/effectiveCallNumberComponents/prefix").asText());
                 okapiItems.put(i.at("/hrid").asText(), itemData);
             });
         }

--- a/service/src/main/java/edu/tamu/catalog/service/VoyagerCatalogService.java
+++ b/service/src/main/java/edu/tamu/catalog/service/VoyagerCatalogService.java
@@ -247,7 +247,7 @@ public class VoyagerCatalogService implements CatalogService {
                 recordValues.get(RECORD_AUTHOR), recordValues.get(RECORD_PUBLISHER), recordValues.get(RECORD_PLACE),
                 recordValues.get(RECORD_YEAR), recordValues.get(RECORD_GENRE), recordValues.get(RECORD_EDITION),
                 holdingValues.get(RECORD_FALLBACK_LOCATION_CODE), recordValues.get(RECORD_OCLC),
-                recordValues.get(RECORD_RECORD_ID), holdingValues.get(RECORD_CALL_NUMBER), holdingValues.get(RECORD_FALLBACK_LOCATION_CODE),
+                recordValues.get(RECORD_RECORD_ID), holdingValues.get(RECORD_CALL_NUMBER), null, holdingValues.get(RECORD_FALLBACK_LOCATION_CODE),
                 new ArrayList<Note>(), new ArrayList<String>(), Boolean.valueOf(holdingValues.get(RECORD_VALID_LARGE_VOLUME)),
                 new HashMap<String, Map<String, String>>(catalogItems));
 


### PR DESCRIPTION
# Description

This PR adds the Call Number Prefix to the HoldingsRecord at the holding and item levels.

I've heard that the prefix has been requested to be added for Cushing GIFM requests. A corresponding GIFMService PR will be opened to utilize the new field.

This change has **not** been tested against an actual FOLIO instance.

There are changes to the domain model that would prevent backwards compatibility for clients using a constructor for HoldingsRecord rather than the Lombok Builder.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

HoldingsRecordTest was updated to include the new field where relevant.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

