### PR TITLE
Upgrade Weaver Core to 2.1.1.

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>edu.tamu.weaver</groupId>
       <artifactId>core</artifactId>
-      <version>2.1.1-RC15</version>
+      <version>2.1.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Upgrade Weaver WebService Core to 2.1.1.

There is also no actual formal `2.1.1-RC15` release, so we shouldn't be using that version.

see: https://github.com/TAMULib/Weaver-Webservice-Core/releases
see: https://artifacts.library.tamu.edu/#browse/browse:maven-releases:edu%2Ftamu%2Fweaver%2Fcore%2F2.1.1-RC15%2Fcore-2.1.1-RC15.pom
see: https://github.com/TAMULib/Weaver-Webservice-Core/commit/aca4e11837ccbd1ed43909778d104c1a1baca485