### PR TITLE
RTR Sprint3: Issue 202-203: Replace JodaTime with Java time.

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -101,12 +101,6 @@
     </dependency>
 
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.10.14</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <scope>test</scope>

--- a/service/src/main/java/edu/tamu/catalog/exception/RestExceptionHandler.java
+++ b/service/src/main/java/edu/tamu/catalog/exception/RestExceptionHandler.java
@@ -1,5 +1,6 @@
 package edu.tamu.catalog.exception;
 
+import java.time.format.DateTimeParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -76,6 +77,19 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<String> parseError(IllegalArgumentException e, WebRequest request) {
+        logger.error(e.getMessage());
+
+        if (logger.isDebugEnabled()) {
+            e.printStackTrace();
+        }
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .contentType(MediaType.TEXT_PLAIN)
+            .body(e.getMessage());
+    }
+
+    @ExceptionHandler(DateTimeParseException.class)
+    public ResponseEntity<String> parseError(DateTimeParseException e, WebRequest request) {
         logger.error(e.getMessage());
 
         if (logger.isDebugEnabled()) {

--- a/service/src/main/java/edu/tamu/catalog/utility/FolioDateTime.java
+++ b/service/src/main/java/edu/tamu/catalog/utility/FolioDateTime.java
@@ -1,13 +1,165 @@
 package edu.tamu.catalog.utility;
 
-import java.text.ParseException;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+
+import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.List;
+import java.util.SimpleTimeZone;
 
-import org.joda.time.Instant;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.ISODateTimeFormat;
-
+/**
+ * Provide the ability to convert to or parse from dates and times.
+ */
 public class FolioDateTime {
+
+    /**
+     * The date string format to use.
+     */
+    public static final String DATE_STRING_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+
+    /**
+     * The format string representing an HTTP Cookie expire date.
+     */
+    public static final DateTimeFormatter COOKIE_DATE_TIME_FORMAT = DateTimeFormatter
+        .ofPattern("EEE, dd MMM yyyy HH:mm:ss z").withZone(ZoneId.of("UTC"));
+
+    /**
+     * A variation of ISO_LOCAL_TIME down to minutes.
+     */
+    public static final DateTimeFormatter TIME_MINUTES;
+    static {
+        TIME_MINUTES = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .appendValue(HOUR_OF_DAY, 2)
+            .appendLiteral(':')
+            .appendValue(MINUTE_OF_HOUR, 2)
+            .toFormatter();
+    }
+
+    /**
+     * A variation of ISO_LOCAL_TIME down to seconds.
+     */
+    public static final DateTimeFormatter TIME_SECONDS;
+    static {
+        TIME_SECONDS = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(TIME_MINUTES)
+            .appendLiteral(':')
+            .appendValue(SECOND_OF_MINUTE, 2)
+            .toFormatter();
+    }
+
+    /**
+     * A variation of ISO_LOCAL_TIME down to milliseconds.
+     */
+    public static final DateTimeFormatter TIME;
+    static {
+        TIME = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(TIME_SECONDS)
+            .optionalStart()
+            .appendFraction(MILLI_OF_SECOND, 3, 3, true)
+            .parseLenient()
+            .appendOffset("+HHMM", "Z")
+            .parseStrict()
+            .toFormatter();
+    }
+
+    /**
+     * A variation of ISO_LOCAL_TIME down to nanoseconds.
+     */
+    public static final DateTimeFormatter TIME_NANOSECONDS;
+    static {
+        TIME_NANOSECONDS = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(TIME_SECONDS)
+            .optionalStart()
+            .appendFraction(NANO_OF_SECOND, 0, 9, true)
+            .parseLenient()
+            .appendOffset("+HHMM", "Z")
+            .parseStrict()
+            .toFormatter();
+    }
+
+    /**
+     * A variation of ISO_OFFSET_DATE_TIME down to milliseconds.
+     */
+    public static final DateTimeFormatter DATE_TIME;
+    static {
+        DATE_TIME = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE)
+            .appendLiteral('T')
+            .append(TIME)
+            .toFormatter();
+    }
+
+    /**
+     * A variation of ISO_OFFSET_DATE_TIME down to nanoseconds.
+     */
+    public static final DateTimeFormatter DATE_TIME_NANOSECONDS;
+    static {
+        DATE_TIME_NANOSECONDS = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE)
+            .appendLiteral('T')
+            .append(TIME_NANOSECONDS)
+            .toFormatter();
+    }
+
+    /**
+     * Get standard dateTime formatters.
+     *
+     * @return A list of standard formatters.
+     */
+    public static List<DateTimeFormatter> getDateTimeFormatters() {
+        DateTimeFormatter startOfDay = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE)
+            .parseDefaulting(ChronoField.NANO_OF_DAY, 0)
+            .parseDefaulting(ChronoField.OFFSET_SECONDS, 0)
+            .toFormatter();
+
+        return List.of(
+            DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+            DateTimeFormatter.ISO_ZONED_DATE_TIME,
+            DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneOffset.UTC),
+            COOKIE_DATE_TIME_FORMAT,
+            DATE_TIME,
+            DATE_TIME_NANOSECONDS,
+            startOfDay
+        );
+    }
+
+    /**
+     * Convert the Java Date to a Folio Date string.
+     *
+     * The date is converted into "yyyy-MM-dd'T'HH:mm:ss.SSSZ".
+     *
+     * @param date The date to convert.
+     *
+     * @return The converted string.
+     */
+    public static String convert(Date date) {
+        SimpleDateFormat simple = new SimpleDateFormat();
+        simple.setTimeZone(new SimpleTimeZone(0, "UTC"));
+        simple.applyPattern(DATE_STRING_FORMAT);
+
+        return simple.format(date);
+    }
 
     /**
      * Parse the Folio Date, converting it to a Java Date.
@@ -15,27 +167,36 @@ public class FolioDateTime {
      * @param value the Folio date string.
      *
      * @return The parsed Java Date.
-     * @throws ParseException
      */
     public static Date parse(String value) {
-        return ISODateTimeFormat.dateTimeParser()
-            .withZoneUTC()
-            .parseDateTime(value)
-            .toDate();
+        return Date.from(parseZonedDateTime(value).toInstant());
     }
 
     /**
-     * Convert the Java Date to a Folio Date string.
-     * The date is convert to "yyyy-MM-dd'T'HH:mm:ss.SSSZ".
+     * Convert the string to a zoned date and time.
      *
-     * @param Date date to convert.
+     * Multiple common formatters are attempted due to DateTimeFormatter.
      *
-     * @return
-     * @throws ParseException
+     * @param value The date string.
+     *
+     * @return The converted zoned date and time.
      */
-    public static String convert(Date date) {
-        return DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
-            .print(Instant.ofEpochMilli(date.toInstant().toEpochMilli()));
+    public static ZonedDateTime parseZonedDateTime(String value) {
+        List<DateTimeFormatter> formatters = getDateTimeFormatters();
+
+        for (int i = 0; i < formatters.size(); i++) {
+            try {
+                DateTimeFormatter formatter = formatters.get(i);
+
+                return ZonedDateTime.parse(value, formatter).truncatedTo(ChronoUnit.MILLIS);
+            } catch (DateTimeParseException e) {
+                if (i == formatters.size() - 1) {
+                    throw e;
+                }
+            }
+        }
+
+        return ZonedDateTime.parse(value).truncatedTo(ChronoUnit.MILLIS);
     }
 
 }

--- a/service/src/test/java/edu/tamu/catalog/utility/FolioDateTimeTest.java
+++ b/service/src/test/java/edu/tamu/catalog/utility/FolioDateTimeTest.java
@@ -4,10 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -59,9 +59,9 @@ public class FolioDateTimeTest {
     private static Stream<? extends Arguments> argumentsParseWithException() {
         return Stream.of(
           Arguments.of((String) null, NullPointerException.class),
-          Arguments.of("", IllegalArgumentException.class),
-          Arguments.of(" ", IllegalArgumentException.class),
-          Arguments.of("bad date", IllegalArgumentException.class)
+          Arguments.of("", DateTimeParseException.class),
+          Arguments.of(" ", DateTimeParseException.class),
+          Arguments.of("bad date", DateTimeParseException.class)
         );
     }
 


### PR DESCRIPTION
Relates #203 .
Part of #202 .

JodaTime is deprecated and should no longer be used.

The newer code intends to use the Java time, such as `ZonedDateTime`.
Remove the JodaTime dependency and replace all related code.

A new exception handler for `DateTimeParseException` is needed becuse the `DateTimeFormatter` throws this new exception.

The newer Java time is more strict on handling of the date time formats during parsing.
Different common formats must be looped over.
These formats are based on existing work that I did in `mod-circulation`.

Explicitly add the Cookie date time format among the list of date and time formatters.
This is going to be used for processing the HTTP cookie expire properties.

Use `SimpleDateFormat` to convert the `Date` into a string.
The `DateTimeFormat.forPattern()` is very fickle and `SimpleDateFormat` simply works better.
The custom format pattern is now stored in a static string `DATE_STRING_FORMAT`.

see: https://github.com/folio-org/mod-circulation/blob/aeebf9b39517048394de04698a2635be7f7e99e4/src/main/java/org/folio/circulation/support/utils/DateFormatUtil.java

