### PR TITLE
RTR Sprint3: Issue 202-203: Implement Access Token and Refresh Token support.

### DIFF
--- a/service/src/main/java/edu/tamu/catalog/config/FolioTenantConfig.java
+++ b/service/src/main/java/edu/tamu/catalog/config/FolioTenantConfig.java
@@ -1,0 +1,16 @@
+package edu.tamu.catalog.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "tenant")
+public class FolioTenantConfig {
+
+    private String headerName = "X-Okapi-Tenant";
+
+    private String defaultTenant = "public";
+
+}

--- a/service/src/main/java/edu/tamu/catalog/config/FolioTokenConfig.java
+++ b/service/src/main/java/edu/tamu/catalog/config/FolioTokenConfig.java
@@ -1,0 +1,39 @@
+package edu.tamu.catalog.config;
+
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "okapi.auth")
+public class FolioTokenConfig {
+
+    /**
+     * FOLIO Access Token Cookie header name.
+     */
+    @Value("${okapi.auth.accessCookieName:folioAccessToken}")
+    private String accessCookieName;
+
+    /**
+     * An offset in milliseconds to apply when calculating token expiration.
+     *
+     * A value of 15 would mean that a token that expires on or before 15 seconds from "now" is considered expired.
+     */
+    @Value("${okapi.auth.expireOffset:15}")
+    private Long expireOffset;
+
+    /**
+     * The URL path to use when attempting to log into FOLIO.
+     */
+    @Value("${okapi.auth.loginPath:/authn/login-with-expiry}")
+    private String loginPath;
+
+    /**
+     * FOLIO Refresh Token Cookie header name.
+     */
+    @Value("${okapi.auth.refreshCookieName:folioRefreshToken}")
+    private String refreshCookieName;
+
+}

--- a/service/src/main/java/edu/tamu/catalog/model/FolioToken.java
+++ b/service/src/main/java/edu/tamu/catalog/model/FolioToken.java
@@ -1,0 +1,20 @@
+package edu.tamu.catalog.model;
+
+import java.time.ZonedDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A FOLIO token and its associated expiration date.
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class FolioToken {
+
+    private String token;
+
+    private ZonedDateTime expire;
+
+}

--- a/service/src/main/java/edu/tamu/catalog/model/FolioTokens.java
+++ b/service/src/main/java/edu/tamu/catalog/model/FolioTokens.java
@@ -1,0 +1,21 @@
+package edu.tamu.catalog.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * The FOLIO access and refresh tokens for a single login session.
+ *
+ * The X-Okapi-Token is represented by the access token.
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class FolioTokens {
+
+    private FolioToken access;
+
+    private FolioToken refresh;
+
+}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -23,3 +23,15 @@ app:
   http.timeout: 10000
   security.allow-access: http://localhost,http://localhost:8080
   whitelist: 127.0.0.1
+
+tenant:
+  header-name: X-Okapi-Tenant
+  default-tenant: public
+
+okapi:
+  auth:
+    access-cookie-name: folioAccessToken
+    refresh-cookie-name: folioRefreshToken
+
+    expire-offset: 15
+    login-path: /authn/login-with-expiry

--- a/service/src/test/java/edu/tamu/catalog/model/FolioTokenTest.java
+++ b/service/src/test/java/edu/tamu/catalog/model/FolioTokenTest.java
@@ -1,0 +1,69 @@
+package edu.tamu.catalog.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class FolioTokenTest {
+
+    private static final String UUID = "3b0c8c59-88b6-4563-919c-86dac2a5c87d";
+
+    private static final ZonedDateTime NOW = ZonedDateTime.now();
+
+    private FolioToken folioToken;
+
+    @BeforeEach
+    void beforeEach() {
+        folioToken = new FolioToken();
+    }
+
+    @Test
+    void initializeAllArgsTest() {
+        folioToken = new FolioToken(UUID, NOW);
+
+        assertEquals(NOW, getField(folioToken, "expire"));
+        assertEquals(UUID, getField(folioToken, "token"));
+    }
+
+    @Test
+    void initializeNoArgsTest() {
+        assertNull(getField(folioToken, "expire"));
+        assertNull(getField(folioToken, "token"));
+    }
+
+    @Test
+    void getExpireWorksTest() {
+        setField(folioToken, "expire", NOW);
+
+        assertEquals(NOW, folioToken.getExpire());
+    }
+
+    @Test
+    void getIdWorksTest() {
+        setField(folioToken, "token", UUID);
+
+        assertEquals(UUID, folioToken.getToken());
+    }
+
+    @Test
+    void setExpireWorksTest() {
+        setField(folioToken, "expire", null);
+
+        folioToken.setExpire(NOW);
+        assertEquals(NOW, getField(folioToken, "expire"));
+    }
+
+    @Test
+    void setIdWorksTest() {
+        setField(folioToken, "token", null);
+
+        folioToken.setToken(UUID);
+        assertEquals(UUID, getField(folioToken, "token"));
+    }
+
+}

--- a/service/src/test/java/edu/tamu/catalog/model/FolioTokensTest.java
+++ b/service/src/test/java/edu/tamu/catalog/model/FolioTokensTest.java
@@ -1,0 +1,84 @@
+package edu.tamu.catalog.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class FolioTokensTest {
+
+    private static final String UUID_1 = "3b0c8c59-88b6-4563-919c-86dac2a5c87d";
+    private static final String UUID_2 = "1fbd7e9f-d553-47ec-9e2f-0c61ab996ec6";
+
+    private static final ZonedDateTime NOW = ZonedDateTime.now();
+    private static final ZonedDateTime LATER = NOW.plusSeconds(1);
+
+    private static final FolioToken ACCESS = new FolioToken(UUID_1, NOW);
+    private static final FolioToken REFRESH = new FolioToken(UUID_2, LATER);
+
+    private FolioTokens folioTokens;
+
+    @BeforeEach
+    void beforeEach() {
+        folioTokens = new FolioTokens();
+    }
+
+    @Test
+    void initializeAllArgsTest() {
+        folioTokens = new FolioTokens(ACCESS, REFRESH);
+
+        FolioToken access = (FolioToken) getField(folioTokens, "access");
+        FolioToken refresh = (FolioToken) getField(folioTokens, "refresh");
+
+        assertNotNull(access);
+        assertNotNull(refresh);
+
+        assertEquals(ACCESS.getToken(), access.getToken());
+        assertEquals(ACCESS.getExpire(), access.getExpire());
+
+        assertEquals(REFRESH.getToken(), refresh.getToken());
+        assertEquals(REFRESH.getExpire(), refresh.getExpire());
+    }
+
+    @Test
+    void initializeNoArgsTest() {
+        assertNull(getField(folioTokens, "access"));
+        assertNull(getField(folioTokens, "refresh"));
+    }
+
+    @Test
+        void getAccessWorksTest() {
+        setField(folioTokens, "access", ACCESS);
+
+        assertEquals(ACCESS, folioTokens.getAccess());
+    }
+
+    @Test
+        void setAccessWorksTest() {
+        setField(folioTokens, "access", null);
+
+        folioTokens.setAccess(ACCESS);
+        assertEquals(ACCESS, getField(folioTokens, "access"));
+    }
+
+    @Test
+        void getRefreshWorksTest() {
+        setField(folioTokens, "refresh", REFRESH);
+
+        assertEquals(REFRESH, folioTokens.getRefresh());
+    }
+
+    @Test
+        void setRefreshWorksTest() {
+        setField(folioTokens, "refresh", null);
+
+        folioTokens.setRefresh(REFRESH);
+        assertEquals(REFRESH, getField(folioTokens, "refresh"));
+    }
+
+}


### PR DESCRIPTION
Resolves #203 .
Part of #202 .

This creates basic structures for utilizing the Access Token (AT) and Refresh Token (RT).
A `ZonedDateTime` is used to represent the `expires` HTTP cookie property.

The new behavior is now exposed as configuration settings.
These configuration settings are named and structured in exactly the same manner as in `spring-module-core`, `mod-workflow`, and `mod-camunda` for consistency reasons.

The `tenant` default is normally `diku`, but the existing behavior in this project is to use `public`.
This preserves the existing default of `public` for compatibility reasons.

A new property `expireOffset` is provided as a way to trigger the token re-authentication process before a token might expire.
This is done to reduce the chances of the token expiring in-flight.
This behavior can be effectively disabled by setting `expireOffset` to a value of `0`.
