### PR TITLE
Fix BibId error logging and provide API Response payload with proper HTTP status codes.

### DIFF
--- a/service/src/main/java/edu/tamu/catalog/controller/CatalogAccessController.java
+++ b/service/src/main/java/edu/tamu/catalog/controller/CatalogAccessController.java
@@ -3,19 +3,14 @@ package edu.tamu.catalog.controller;
 import static edu.tamu.weaver.response.ApiStatus.ERROR;
 import static edu.tamu.weaver.response.ApiStatus.SUCCESS;
 
-import java.io.IOException;
-import java.util.List;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
 import edu.tamu.catalog.annotation.DefaultCatalog;
 import edu.tamu.catalog.domain.model.HoldingsRecord;
 import edu.tamu.catalog.service.CatalogService;
 import edu.tamu.weaver.response.ApiResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/catalog-access")
@@ -24,17 +19,18 @@ public class CatalogAccessController {
     /**
      * Provides the raw CatalogHolding data
      *
-     * @param CatalogService catalogService (resolved by query parameter catalogName)
-     * @param String bibId
-     * @return
-     * @throws JsonProcessingException
-     * @throws IOException
+     * @param catalogService (resolved by query parameter catalogName).
+     * @param bibId The Bibliographic ID.
+     *
+     * @return The API Response.
+     *
+     * @throws Exception
      */
     @RequestMapping("/get-holdings")
     public ApiResponse getHoldings(
         @DefaultCatalog("evans") CatalogService catalogService,
         @RequestParam(required = true) String bibId
-    ) {
+    ) throws Exception {
         List<HoldingsRecord> catalogHoldings = catalogService.getHoldingsByBibId(bibId);
         if (catalogHoldings != null) {
             return new ApiResponse(SUCCESS, catalogHoldings);
@@ -46,19 +42,20 @@ public class CatalogAccessController {
     /**
      * Provides data for a single CatalogHolding
      *
-     * @param CatalogService catalogService (resolved by query parameter catalogName)
-     * @param String bibId
-     * @param String holdingId
-     * @return
-     * @throws JsonProcessingException
-     * @throws IOException
+     * @param catalogService (resolved by query parameter catalogName)
+     * @param bibId The Bibliographic ID.
+     * @param holdingId The Holdings ID.
+     *
+     * @return The API Response.
+     *
+     * @throws Exception
      */
     @RequestMapping("/get-holding")
     public ApiResponse getHolding(
         @DefaultCatalog("evans") CatalogService catalogService,
         @RequestParam(required = true) String bibId,
         @RequestParam(required = true) String holdingId
-    ) {
+    ) throws Exception {
         HoldingsRecord catalogHolding = catalogService.getHolding(bibId, holdingId);
         if (catalogHolding != null) {
             return new ApiResponse(SUCCESS, catalogHolding);

--- a/service/src/main/java/edu/tamu/catalog/exception/BibIdNotFoundError.java
+++ b/service/src/main/java/edu/tamu/catalog/exception/BibIdNotFoundError.java
@@ -1,0 +1,13 @@
+package edu.tamu.catalog.exception;
+
+public class BibIdNotFoundError extends Exception {
+
+    private static final long serialVersionUID = 1005770155872425525L;
+
+    private static final String MESSAGE = "No instances found with a Bibliographic ID of %s for %s catalog.";
+
+    public BibIdNotFoundError(String id, String catalog) {
+        super(String.format(MESSAGE, id, catalog));
+    }
+
+}

--- a/service/src/main/java/edu/tamu/catalog/exception/HoldingsRequestError.java
+++ b/service/src/main/java/edu/tamu/catalog/exception/HoldingsRequestError.java
@@ -1,0 +1,53 @@
+package edu.tamu.catalog.exception;
+
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+public class HoldingsRequestError extends Exception {
+
+    private static final long serialVersionUID = 1672631211195165509L;
+
+    private static final String ERROR_ATTR_CODE = "code";
+    private static final String MESSAGE = "Failed to get holdings for %s catalog due to: %s.";
+
+    public HoldingsRequestError(NodeList errorNodes, String catalog) {
+        super(buildMessage(errorNodes, catalog));
+    }
+
+    /**
+     * Construct the message string.
+     *
+     * @param errorNodes The error nodes returned by a restTemplate.getForObject() call.
+     * @param catalog The catalog associated with the error.
+     *
+     * @return The constructed string.
+     */
+    private static String buildMessage(NodeList errorNodes, String catalog) {
+        StringBuilder builder = new StringBuilder();
+
+        for (int i = 0; i < errorNodes.getLength(); i++) {
+            Node node = errorNodes.item(i);
+            Node code = node.getAttributes().getNamedItem(ERROR_ATTR_CODE);
+
+            String codeValue = code == null ? "" : code.getTextContent();
+            String nodeValue = node == null ? "" : node.getTextContent();
+
+            builder.append(String.format("Error '%s': %s ", codeValue, nodeValue));
+        }
+
+        // Remove the trailing space.
+        if (builder.length() > 0) {
+            builder.setLength(builder.length() - 1);
+        }
+
+        // Remove the trailing period.
+        if (builder.length() > 0) {
+            if (builder.charAt(builder.length() - 1) == '.') {
+                builder.setLength(builder.length() - 1);
+            }
+        }
+
+        return String.format(MESSAGE, catalog, builder.toString());
+    }
+
+}

--- a/service/src/main/java/edu/tamu/catalog/exception/RemoteServerError.java
+++ b/service/src/main/java/edu/tamu/catalog/exception/RemoteServerError.java
@@ -1,0 +1,64 @@
+package edu.tamu.catalog.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class RemoteServerError extends Exception {
+
+    private static final long serialVersionUID = -22660189803028941L;
+
+    private static final String MESSAGE = "Failed to access remote server for %s catalog due to %s.";
+
+    private String details;
+
+    private String method;
+
+    private HttpStatus statusCode;
+
+    private String url;
+
+    public RemoteServerError(String method, String url, String catalog, HttpStatus statusCode, String message) {
+        super(String.format(MESSAGE, catalog, statusCode.toString()));
+
+        this.details = message;
+        this.method = method;
+        this.statusCode = statusCode;
+        this.url = url;
+    }
+
+    /**
+     * The response message associated with this exception.
+     *
+     *  @return The response message.
+     */
+    public String getDetails() {
+        return details;
+    }
+
+    /**
+     * The request method associated with this exception.
+     *
+     *  @return The request method.
+     */
+    public String getMethod() {
+        return method;
+    }
+
+    /**
+     * The response status code associated with this exception.
+     *
+     *  @return The request method.
+     */
+    public HttpStatus getStatusCode() {
+        return statusCode;
+    }
+
+    /**
+     * The URL associated with this exception.
+     *
+     *  @return The URL.
+     */
+    public String getUrl() {
+        return url;
+    }
+
+}

--- a/service/src/main/java/edu/tamu/catalog/exception/RestExceptionHandler.java
+++ b/service/src/main/java/edu/tamu/catalog/exception/RestExceptionHandler.java
@@ -1,5 +1,10 @@
 package edu.tamu.catalog.exception;
 
+import static edu.tamu.weaver.response.ApiStatus.ERROR;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.tamu.weaver.response.ApiResponse;
 import java.time.format.DateTimeParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,28 +25,23 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
+    @ExceptionHandler(BibIdNotFoundError.class)
+    public ResponseEntity<String> bibIdNotFoundError(BibIdNotFoundError e, WebRequest request) {
+        logErrors(e);
+
+        return buildApiResponseEntity(e.getMessage(), HttpStatus.NOT_FOUND, MediaType.APPLICATION_JSON);
+    }
 
     @ExceptionHandler(RenewFailureException.class)
     public ResponseEntity<String> renewError(RenewFailureException e, WebRequest request) {
-        logger.warn(e.getMessage());
+        logErrors(e);
 
-        if (logger.isDebugEnabled()) {
-            e.printStackTrace();
-        }
-
-        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
-            .contentType(MediaType.TEXT_PLAIN)
-            .body(RENEWAL_DID_NOT_CHANGE_THE_DUE_DATE);
+        return buildApiResponseEntity(RENEWAL_DID_NOT_CHANGE_THE_DUE_DATE, HttpStatus.UNPROCESSABLE_ENTITY, MediaType.APPLICATION_JSON);
     }
 
     @ExceptionHandler(HttpClientErrorException.class)
     public ResponseEntity<String> clientError(HttpClientErrorException e, WebRequest request) {
-        logger.warn(e.getMessage());
-
-        if (logger.isDebugEnabled()) {
-            logger.warn(e.getResponseBodyAsString());
-            e.printStackTrace();
-        }
+        logErrors(e);
 
         return ResponseEntity.status(e.getRawStatusCode())
             .contentType(MediaType.APPLICATION_JSON)
@@ -50,12 +50,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(HttpServerErrorException.class)
     public ResponseEntity<String> serverError(HttpServerErrorException e, WebRequest request) {
-        logger.error(e.getMessage());
-
-        if (logger.isDebugEnabled()) {
-            e.printStackTrace();
-            logger.error(e.getResponseBodyAsString());
-        }
+        logErrors(e);
 
         return ResponseEntity.status(e.getRawStatusCode())
             .contentType(MediaType.APPLICATION_JSON)
@@ -64,41 +59,65 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(UnsupportedOperationException.class)
     public ResponseEntity<String> unsupportedOperationError(UnsupportedOperationException e, WebRequest request) {
-        logger.warn(e.getMessage());
+        logErrors(e);
 
-        if (logger.isDebugEnabled()) {
-            e.printStackTrace();
-        }
-
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .contentType(MediaType.TEXT_PLAIN)
-            .body(e.getMessage());
+        return buildApiResponseEntity(e.getMessage(), HttpStatus.BAD_REQUEST, MediaType.APPLICATION_JSON);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<String> parseError(IllegalArgumentException e, WebRequest request) {
-        logger.error(e.getMessage());
+        logErrors(e);
 
-        if (logger.isDebugEnabled()) {
-            e.printStackTrace();
-        }
-
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .contentType(MediaType.TEXT_PLAIN)
-            .body(e.getMessage());
+        return buildApiResponseEntity(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR, MediaType.APPLICATION_JSON);
     }
 
     @ExceptionHandler(DateTimeParseException.class)
     public ResponseEntity<String> parseError(DateTimeParseException e, WebRequest request) {
+        logErrors(e);
+
+        return buildApiResponseEntity(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR, MediaType.APPLICATION_JSON);
+    }
+
+    /**
+     * Handle the logging of the exceptions.
+     *
+     * @param e The exception to log.
+     */
+    private void logErrors(Exception e) {
         logger.error(e.getMessage());
 
         if (logger.isDebugEnabled()) {
             e.printStackTrace();
         }
+    }
 
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .contentType(MediaType.TEXT_PLAIN)
-            .body(e.getMessage());
+    /**
+     * Build response message as an API Response.
+     *
+     * This allows for passing through the HTTP status codes while still preserving the API Response behavior.
+     *
+     * @param message The message in the API Response.
+     * @param status The status code.
+     * @param type The HTTP payload type.
+     *
+     * @return The constructed resonse entity.
+     */
+    private ResponseEntity<String> buildApiResponseEntity(String message, HttpStatus status, MediaType type) {
+        ObjectMapper mapper = new ObjectMapper();
+
+        // The exception handler should ideally not throw its own exceptions.
+        // Catch the exceptions and report it, then fall back to a plain text error message.
+        try {
+            message = mapper.writeValueAsString(new ApiResponse(ERROR, message));
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+
+            type = MediaType.TEXT_PLAIN;
+        }
+
+        return ResponseEntity.status(status)
+            .contentType(type)
+            .body(message);
     }
 
 }

--- a/service/src/main/java/edu/tamu/catalog/exception/RestExceptionHandler.java
+++ b/service/src/main/java/edu/tamu/catalog/exception/RestExceptionHandler.java
@@ -39,6 +39,17 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
         return buildApiResponseEntity(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR, MediaType.APPLICATION_JSON);
     }
 
+    @ExceptionHandler(RemoteServerError.class)
+    public ResponseEntity<String> restServerError(RemoteServerError e, WebRequest request) {
+        logger.error("Failed to {} {}: {} with response payload:\n\t{}.", e.getMethod(), e.getUrl(), e.getMessage(), e.getDetails());
+
+        if (logger.isDebugEnabled()) {
+            e.printStackTrace();
+        }
+
+        return buildApiResponseEntity(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR, MediaType.APPLICATION_JSON);
+    }
+
     @ExceptionHandler(RenewFailureException.class)
     public ResponseEntity<String> renewError(RenewFailureException e, WebRequest request) {
         logErrors(e);

--- a/service/src/main/java/edu/tamu/catalog/exception/RestExceptionHandler.java
+++ b/service/src/main/java/edu/tamu/catalog/exception/RestExceptionHandler.java
@@ -32,6 +32,13 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
         return buildApiResponseEntity(e.getMessage(), HttpStatus.NOT_FOUND, MediaType.APPLICATION_JSON);
     }
 
+    @ExceptionHandler(HoldingsRequestError.class)
+    public ResponseEntity<String> bibIdNotFoundError(HoldingsRequestError e, WebRequest request) {
+        logErrors(e);
+
+        return buildApiResponseEntity(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR, MediaType.APPLICATION_JSON);
+    }
+
     @ExceptionHandler(RenewFailureException.class)
     public ResponseEntity<String> renewError(RenewFailureException e, WebRequest request) {
         logErrors(e);

--- a/service/src/main/java/edu/tamu/catalog/service/CatalogService.java
+++ b/service/src/main/java/edu/tamu/catalog/service/CatalogService.java
@@ -18,9 +18,9 @@ public interface CatalogService {
 
     String getName();
 
-    List<HoldingsRecord> getHoldingsByBibId(String bibId);
+    List<HoldingsRecord> getHoldingsByBibId(String bibId) throws Exception;
 
-    HoldingsRecord getHolding(String id, String holdingId);
+    HoldingsRecord getHolding(String id, String holdingId) throws Exception;
 
     List<FeeFine> getFeesFines(String uin) throws Exception;
 

--- a/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
+++ b/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
@@ -31,6 +31,7 @@ import edu.tamu.catalog.domain.model.HoldRequest;
 import edu.tamu.catalog.domain.model.HoldingsRecord;
 import edu.tamu.catalog.domain.model.LoanItem;
 import edu.tamu.catalog.domain.model.Note;
+import edu.tamu.catalog.exception.BibIdNotFoundError;
 import edu.tamu.catalog.exception.RenewFailureException;
 import edu.tamu.catalog.model.FolioHoldCancellation;
 import edu.tamu.catalog.model.FolioToken;
@@ -143,13 +144,31 @@ public class FolioCatalogService implements CatalogService {
     }
 
     @Override
-    public List<HoldingsRecord> getHoldingsByBibId(String id) {
+    public List<HoldingsRecord> getHoldingsByBibId(String id) throws Exception {
         String instanceId = null;
-        //if it's not a uuid, assume hrid and try to get the uuid from the instance data
+
+        // If it's not a uuid, assume hrid and try to get the uuid from the instance data
         if (!isUUID(id)) {
+            JsonNode instanceData = getInstanceByHrid(id);
+            JsonNode instances = null;
+
+            if (instanceData != null && instanceData.size() > 0) {
+                instances = instanceData.at("/instances");
+            }
+
+            if (instances == null || instances.size() == 0) {
+                throw new BibIdNotFoundError(id, this.getName());
+            }
+
             try {
-                JsonNode instanceData = getInstanceByHrid(id);
-                instanceId = instanceData.at("/instances").get(0).at("/id").asText();
+                JsonNode instance = instances.get(0).at("/id");
+
+                if (instance == null) {
+                    logger.error("Error retrieving instance by hrid: {}", id);
+                    return null;
+                }
+
+                instanceId = instance.asText();
             } catch (Exception e) {
                 logger.error("Error retrieving instance by hrid: {}", id);
                 e.printStackTrace();
@@ -158,6 +177,7 @@ public class FolioCatalogService implements CatalogService {
         } else {
             instanceId = id;
         }
+
         return requestHoldings(instanceId, null);
     }
 

--- a/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
+++ b/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
@@ -33,6 +33,7 @@ import edu.tamu.catalog.domain.model.LoanItem;
 import edu.tamu.catalog.domain.model.Note;
 import edu.tamu.catalog.exception.BibIdNotFoundError;
 import edu.tamu.catalog.exception.HoldingsRequestError;
+import edu.tamu.catalog.exception.RemoteServerError;
 import edu.tamu.catalog.exception.RenewFailureException;
 import edu.tamu.catalog.model.FolioHoldCancellation;
 import edu.tamu.catalog.model.FolioToken;
@@ -201,7 +202,7 @@ public class FolioCatalogService implements CatalogService {
 
         logger.debug("Asking for fines from: {}", url);
 
-        JsonNode node = restTemplate.getForObject(url, JsonNode.class, apiKey);
+        JsonNode node = restGet(url, JsonNode.class, apiKey);
 
         List<FeeFine> list = new ArrayList<>();
 
@@ -236,7 +237,7 @@ public class FolioCatalogService implements CatalogService {
 
         logger.debug("Asking for patron loans from: {}", url);
 
-        JsonNode node = restTemplate.getForObject(url, JsonNode.class, apiKey);
+        JsonNode node = restGet(url, JsonNode.class, apiKey);
 
         List<LoanItem> list = new ArrayList<>();
 
@@ -328,7 +329,7 @@ public class FolioCatalogService implements CatalogService {
 
         logger.debug("Asking for patron hold requests from: {}", url);
 
-        JsonNode node = restTemplate.getForObject(url, JsonNode.class, apiKey);
+        JsonNode node = restGet(url, JsonNode.class, apiKey);
 
         List<HoldRequest> list = new ArrayList<>();
 
@@ -680,8 +681,9 @@ public class FolioCatalogService implements CatalogService {
      * @return list of holdings records.
      *
      * @throws HoldingsRequestError
+     * @throws RemoteServerError
      */
-    private List<HoldingsRecord> requestHoldings(String instanceId, String holdingId) throws HoldingsRequestError {
+    private List<HoldingsRecord> requestHoldings(String instanceId, String holdingId) throws HoldingsRequestError, RemoteServerError {
         List<HoldingsRecord> finalHoldings = new ArrayList<>();
 
         try {
@@ -698,7 +700,7 @@ public class FolioCatalogService implements CatalogService {
 
             logger.debug("Asking for edge holdings from: {}", url);
 
-            String result = restTemplate.getForObject(url, String.class);
+            String result = restGet(url, String.class);
 
             DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
             DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
@@ -1536,6 +1538,28 @@ public class FolioCatalogService implements CatalogService {
         }
 
         return null;
+    }
+
+    /**
+     * Perform the request request, catching the exceptions.
+     *
+     * Catch the remote server client and server exceptions and throw a more controlled one.
+     * This ensures that a proper JSON error response is returned with more detailed system logging. 
+     *
+     * @param <T> The response type.
+     * @param url The request URL.
+     * @param responseType The response type class.
+     * @param uriVariables Any additional variables.
+     *
+     * @return The response result.
+     * @throws RemoteServerError
+     */
+    private <T> T restGet(String url, Class<T> responseType, Object... uriVariables) throws RemoteServerError {
+        try {
+            return restTemplate.getForObject(url, responseType, uriVariables);
+        } catch (HttpServerErrorException | HttpClientErrorException ex) {
+            throw new RemoteServerError("GET", url, getName(), ex.getStatusCode(), ex.getMessage());
+        }
     }
 
 }

--- a/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
+++ b/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
@@ -32,6 +32,7 @@ import edu.tamu.catalog.domain.model.HoldingsRecord;
 import edu.tamu.catalog.domain.model.LoanItem;
 import edu.tamu.catalog.domain.model.Note;
 import edu.tamu.catalog.exception.BibIdNotFoundError;
+import edu.tamu.catalog.exception.HoldingsRequestError;
 import edu.tamu.catalog.exception.RenewFailureException;
 import edu.tamu.catalog.model.FolioHoldCancellation;
 import edu.tamu.catalog.model.FolioToken;
@@ -93,7 +94,6 @@ public class FolioCatalogService implements CatalogService {
     private static final Map<String, JsonNode> SERVICE_POINT_CACHE = new ConcurrentHashMap<>();
     private static final Map<String, JsonNode> LOAN_POLICY_CACHE = new ConcurrentHashMap<>();
 
-    private static final String ERROR_ATTR_CODE = "code";
     private static final String EXPIRES = "expires";
     private static final String METADATA_PREFIX = "marc21_withholdings";
     private static final String NODE_PREFIX = "marc:";
@@ -182,7 +182,7 @@ public class FolioCatalogService implements CatalogService {
     }
 
     @Override
-    public HoldingsRecord getHolding(String instanceId, String holdingId) {
+    public HoldingsRecord getHolding(String instanceId, String holdingId) throws Exception {
         List<HoldingsRecord> holdings = requestHoldings(instanceId, holdingId);
 
         if (holdings.size() > 0) {
@@ -674,12 +674,14 @@ public class FolioCatalogService implements CatalogService {
     /**
      * Process the Holdings.
      *
-     * @param instanceId String
-     * @param holdingId String
+     * @param instanceId The instance ID.
+     * @param holdingId The holdings ID.
      *
-     * @return list of holdings records
+     * @return list of holdings records.
+     *
+     * @throws HoldingsRequestError
      */
-    private List<HoldingsRecord> requestHoldings(String instanceId, String holdingId) {
+    private List<HoldingsRecord> requestHoldings(String instanceId, String holdingId) throws HoldingsRequestError {
         List<HoldingsRecord> finalHoldings = new ArrayList<>();
 
         try {
@@ -707,16 +709,8 @@ public class FolioCatalogService implements CatalogService {
 
             NodeList errorNodes = doc.getElementsByTagName(NODE_ERROR);
 
-            // TODO: this potentially has one or more errors, be sure to determine how to handle the "or more" part.
-            if (errorNodes.getLength() > 0) {
-                Node node = errorNodes.item(0);
-                Node code = node.getAttributes().getNamedItem(ERROR_ATTR_CODE);
-
-                String codeValue = code == null ? "" : code.getTextContent();
-                String nodeValue = node == null ? "" : node.getTextContent();
-
-                // http://www.openarchives.org/OAI/openarchivesprotocol.html#ErrorConditions
-                throw new IOException(String.format("Error '%s': %s", codeValue, nodeValue));
+            if (errorNodes != null && errorNodes.getLength() > 0) {
+                throw new HoldingsRequestError(errorNodes, getName());
             }
 
             NodeList verbNodes = doc.getElementsByTagName(VERB_GET_RECORD);

--- a/service/src/test/java/edu/tamu/catalog/controller/CatalogAccessControllerTest.java
+++ b/service/src/test/java/edu/tamu/catalog/controller/CatalogAccessControllerTest.java
@@ -36,7 +36,7 @@ public class CatalogAccessControllerTest {
     }
 
     @Test
-    public void testGetHoldingsSuccess() {
+    public void testGetHoldingsSuccess() throws Exception {
         when(folioCatalogService.getHoldingsByBibId(any(String.class))).thenReturn(new ArrayList<HoldingsRecord>());
 
         ApiResponse response = catalogAccessController.getHoldings(folioCatalogService, "foo");
@@ -44,7 +44,7 @@ public class CatalogAccessControllerTest {
     }
 
     @Test
-    public void testGetHoldingsFailure() {
+    public void testGetHoldingsFailure() throws Exception {
         when(folioCatalogService.getHoldingsByBibId(any(String.class))).thenReturn(null);
 
         ApiResponse response = catalogAccessController.getHoldings(folioCatalogService, "foo");
@@ -52,7 +52,7 @@ public class CatalogAccessControllerTest {
     }
 
     @Test
-    public void testGetHoldingSuccess() {
+    public void testGetHoldingSuccess() throws Exception {
         Map<String, Map<String, String>> catalogItems = new HashMap<>();
         HoldingsRecord holding =  HoldingsRecord.builder()
             .recordId("recordId")
@@ -81,7 +81,7 @@ public class CatalogAccessControllerTest {
     }
 
     @Test
-    public void testGetHoldingFailure() {
+    public void testGetHoldingFailure() throws Exception {
         when(folioCatalogService.getHolding(any(String.class), any(String.class))).thenReturn(null);
 
         ApiResponse response = catalogAccessController.getHolding(folioCatalogService, "foo", "bar");

--- a/service/src/test/java/edu/tamu/catalog/controller/PatronControllerTest.java
+++ b/service/src/test/java/edu/tamu/catalog/controller/PatronControllerTest.java
@@ -416,10 +416,10 @@ public class PatronControllerTest extends PatronControllerTestBase {
         return Stream.of(
             Arguments.of(holds, getHoldsUrl(), never(), once(), never(), never(),
                 withStatus(NOT_FOUND), withNoContent(),
-                withNoContent(), status().isNotFound()),
+                withNoContent(), status().isInternalServerError()),
             Arguments.of(holds, getHoldsUrl(), never(), once(), never(), never(),
                 withStatus(BAD_REQUEST), withNoContent(),
-                withNoContent(), status().isBadRequest()),
+                withNoContent(), status().isInternalServerError()),
             Arguments.of(holds, getHoldsUrl(), never(), once(), never(), never(),
                 withStatus(INTERNAL_SERVER_ERROR), withNoContent(),
                 withNoContent(), status().isInternalServerError()),
@@ -484,8 +484,8 @@ public class PatronControllerTest extends PatronControllerTestBase {
             .accept(MediaType.APPLICATION_JSON, MediaType.TEXT_HTML);
 
         return Stream.of(
-            Arguments.of(loans, getLoansUrl(), GET, once(), withStatus(NOT_FOUND), status().isNotFound()),
-            Arguments.of(loans, getLoansUrl(), GET, once(), withStatus(BAD_REQUEST), status().isBadRequest()),
+            Arguments.of(loans, getLoansUrl(), GET, once(), withStatus(NOT_FOUND), status().isInternalServerError()),
+            Arguments.of(loans, getLoansUrl(), GET, once(), withStatus(BAD_REQUEST), status().isInternalServerError()),
             Arguments.of(loans, getLoansUrl(), GET, once(), withStatus(INTERNAL_SERVER_ERROR),
                 status().isInternalServerError()),
             Arguments.of(loansCatalog, getLoansUrl(), GET, never(), withStatus(OK), status().isBadRequest()),
@@ -525,8 +525,8 @@ public class PatronControllerTest extends PatronControllerTestBase {
             .accept(MediaType.APPLICATION_JSON, MediaType.TEXT_HTML);
 
         return Stream.of(
-            Arguments.of(fines, getFinesUrl(), GET, once(), withStatus(NOT_FOUND), status().isNotFound()),
-            Arguments.of(fines, getFinesUrl(), GET, once(), withStatus(BAD_REQUEST), status().isBadRequest()),
+            Arguments.of(fines, getFinesUrl(), GET, once(), withStatus(NOT_FOUND), status().isInternalServerError()),
+            Arguments.of(fines, getFinesUrl(), GET, once(), withStatus(BAD_REQUEST), status().isInternalServerError()),
             Arguments.of(fines, getFinesUrl(), GET, once(), withStatus(INTERNAL_SERVER_ERROR),
                 status().isInternalServerError()),
             Arguments.of(finesCatalog, getFinesUrl(), GET, never(), withStatus(OK), status().isBadRequest()),

--- a/service/src/test/java/edu/tamu/catalog/exception/BibIdNotFoundErrorTest.java
+++ b/service/src/test/java/edu/tamu/catalog/exception/BibIdNotFoundErrorTest.java
@@ -2,7 +2,6 @@ package edu.tamu.catalog.exception;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,14 +14,14 @@ public class BibIdNotFoundErrorTest {
     private static final String CATALOG = "Some Catalog";
 
     @Test
-    void delegateSpinFailureWorksTest() throws IOException {
-          BibIdNotFoundError exception = Assertions.assertThrows(BibIdNotFoundError.class, () -> {
-          throw new BibIdNotFoundError(ID, CATALOG);
-      });
+    void bibIdNotFoundErrorWorksTest() {
+        BibIdNotFoundError exception = Assertions.assertThrows(BibIdNotFoundError.class, () -> {
+            throw new BibIdNotFoundError(ID, CATALOG);
+        });
 
-      assertNotNull(exception);
-      assertTrue(exception.getMessage().contains(ID));
-      assertTrue(exception.getMessage().contains(CATALOG));
+        assertNotNull(exception);
+        assertTrue(exception.getMessage().contains(ID));
+        assertTrue(exception.getMessage().contains(CATALOG));
     }
 
 }

--- a/service/src/test/java/edu/tamu/catalog/exception/BibIdNotFoundErrorTest.java
+++ b/service/src/test/java/edu/tamu/catalog/exception/BibIdNotFoundErrorTest.java
@@ -1,0 +1,28 @@
+package edu.tamu.catalog.exception;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class BibIdNotFoundErrorTest {
+
+    private static final String ID = "The ID.";
+    private static final String CATALOG = "Some Catalog";
+
+    @Test
+    void delegateSpinFailureWorksTest() throws IOException {
+          BibIdNotFoundError exception = Assertions.assertThrows(BibIdNotFoundError.class, () -> {
+          throw new BibIdNotFoundError(ID, CATALOG);
+      });
+
+      assertNotNull(exception);
+      assertTrue(exception.getMessage().contains(ID));
+      assertTrue(exception.getMessage().contains(CATALOG));
+    }
+
+}

--- a/service/src/test/java/edu/tamu/catalog/exception/HoldingsRequestErrorTest.java
+++ b/service/src/test/java/edu/tamu/catalog/exception/HoldingsRequestErrorTest.java
@@ -1,0 +1,74 @@
+package edu.tamu.catalog.exception;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+@ExtendWith(MockitoExtension.class)
+public class HoldingsRequestErrorTest {
+
+    private static final String CATALOG = "Some Catalog";
+    private static final String FIRST_CODE = "first code";
+    private static final String FIRST_DATA = "first data";
+    private static final String SECOND_CODE = "second code";
+    private static final String SECOND_DATA = "second data";
+
+    @Mock
+    NodeList mockList;
+
+    @Mock
+    Node firstCode;
+
+    @Mock
+    Node firstNode;
+
+    @Mock
+    Node secondCode;
+
+    @Mock
+    Node secondNode;
+
+    @Mock
+    NamedNodeMap firstMap;
+
+    @Mock
+    NamedNodeMap secondMap;
+
+    @Test
+    void holdingsRequestErrorWorksTest() {
+        when(mockList.getLength()).thenReturn(2);
+
+        when(mockList.item(0)).thenReturn(firstNode);
+        when(firstNode.getAttributes()).thenReturn(firstMap);
+        when(firstMap.getNamedItem(anyString())).thenReturn(firstCode);
+        when(firstCode.getTextContent()).thenReturn(FIRST_CODE);
+        when(firstNode.getTextContent()).thenReturn(FIRST_DATA);
+
+        when(mockList.item(1)).thenReturn(secondNode);
+        when(secondNode.getAttributes()).thenReturn(secondMap);
+        when(secondMap.getNamedItem(anyString())).thenReturn(secondCode);
+        when(secondCode.getTextContent()).thenReturn(SECOND_CODE);
+        when(secondNode.getTextContent()).thenReturn(SECOND_DATA);
+
+        HoldingsRequestError exception = Assertions.assertThrows(HoldingsRequestError.class, () -> {
+            throw new HoldingsRequestError(mockList, CATALOG);
+        });
+
+        assertNotNull(exception);
+        assertTrue(exception.getMessage().contains(CATALOG));
+        assertTrue(exception.getMessage().contains(FIRST_CODE));
+        assertTrue(exception.getMessage().contains(FIRST_DATA));
+        assertTrue(exception.getMessage().contains(SECOND_CODE));
+        assertTrue(exception.getMessage().contains(SECOND_DATA));
+    }
+
+}

--- a/service/src/test/java/edu/tamu/catalog/exception/RemoteServerErrorTest.java
+++ b/service/src/test/java/edu/tamu/catalog/exception/RemoteServerErrorTest.java
@@ -1,0 +1,38 @@
+package edu.tamu.catalog.exception;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+public class RemoteServerErrorTest {
+
+    private static final String CATALOG = "Some Catalog";
+    private static final String DETAILS = "The details.";
+    private static final String GET = "HTTP GET";
+    private static final String URL = "http://localhost/some/url";
+
+    private static final HttpStatus STATUS = HttpStatus.NOT_FOUND;
+
+    @Test
+    void remoteServerErrorWorksTest() {
+        RemoteServerError exception = Assertions.assertThrows(RemoteServerError.class, () -> {
+            throw new RemoteServerError(GET, URL, CATALOG, STATUS, DETAILS);
+        });
+
+        assertNotNull(exception);
+        assertTrue(exception.getMessage().contains(CATALOG));
+        assertTrue(exception.getMessage().contains(STATUS.toString()));
+
+        // These are printed to the system log rather than the user and should not appear in the message itself.
+        assertFalse(exception.getMessage().contains(DETAILS));
+        assertFalse(exception.getMessage().contains(GET));
+        assertFalse(exception.getMessage().contains(URL));
+    }
+
+}

--- a/service/src/test/java/edu/tamu/catalog/exception/RenewFailureExceptionTest.java
+++ b/service/src/test/java/edu/tamu/catalog/exception/RenewFailureExceptionTest.java
@@ -2,7 +2,6 @@ package edu.tamu.catalog.exception;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,13 +13,13 @@ public class RenewFailureExceptionTest {
     private static final String MESSAGE = "Some Message";
 
     @Test
-    void delegateSpinFailureWorksTest() throws IOException {
-          RenewFailureException exception = Assertions.assertThrows(RenewFailureException.class, () -> {
-          throw new RenewFailureException(MESSAGE);
-      });
+    void delegateSpinFailureWorksTest() {
+       RenewFailureException exception = Assertions.assertThrows(RenewFailureException.class, () -> {
+           throw new RenewFailureException(MESSAGE);
+       });
 
-      assertNotNull(exception);
-      assertTrue(exception.getMessage().contains(MESSAGE));
+       assertNotNull(exception);
+       assertTrue(exception.getMessage().contains(MESSAGE));
    }
 
 }

--- a/service/src/test/java/edu/tamu/catalog/exception/RenewFailureExceptionTest.java
+++ b/service/src/test/java/edu/tamu/catalog/exception/RenewFailureExceptionTest.java
@@ -1,0 +1,26 @@
+package edu.tamu.catalog.exception;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class RenewFailureExceptionTest {
+
+    private static final String MESSAGE = "Some Message";
+
+    @Test
+    void delegateSpinFailureWorksTest() throws IOException {
+          RenewFailureException exception = Assertions.assertThrows(RenewFailureException.class, () -> {
+          throw new RenewFailureException(MESSAGE);
+      });
+
+      assertNotNull(exception);
+      assertTrue(exception.getMessage().contains(MESSAGE));
+   }
+
+}


### PR DESCRIPTION
_Note: This project still requires **Java 11**._

If an invalid ID is passed to the system log shows a rather unhelpful null pointer exception. Improve the error logging by throwing an exception with an explicit message.

The `ApiResponse` always returns `HTTP 200`, even on errors, not founds, etc... Utilize the exception handlers to return proper HTTP status codes while still preserving the existing behavior of an API Response.

Many programs that depend on this might be hard-coded to always expect an HTTP 200, even for errors. Returning a proper HTTP status code might require these programs to be updated.

There are some exceptions already being handled that pass along a JSON response and status code already. These are left alone (they already do not return an `ApiResponse`).

This only implements the basic functionality of this HTTP status code for specific cases. With this approach, all of the exceptions could be handled this way and the controllers could potentially have reduced need for some conditional checks in them.

~_Note: This is submitted as a draft for pre-reviewing.
Therefore, reviewers are tagged not as a reviewer for merging but instead as a reviewer of the proof of concept designs within this PR._~
This PR is now accepted onto the Eureka Sprint.


### Additional Changes

Add `HoldingsRequestError` to handle more problems and perform other minor fixes.
  
The DEV environment is failing with during an upgrade process:
```json
{"meta":{"status":"SUCCESS","action":null,"message":"Your request was successful","id":null},"payload":{"ArrayList":[]}}
```

This should actually be an error.

Change the code to properly handle this error, thus yielding the following:
```json
{"meta":{"status":"ERROR","action":null,"message":"Failed to get holdings for folio catalog due to: Error 'badArgument': Identifier has invalid structure.","id":null},"payload":{}}
```

This also addresses the situation where multiple errors might be returned.
These errors are concatenated by the exception.

Fix tabbing/spacing in some of the recently changed files.

Improve handling of remote server error responses.

Bad error messages where HTML is being returned with a mimetype of `application/json` while containing details from the remote server.
The HTTP status code being returned is also incorrect.
The 404 should not be returned to the user because the current path is valid and does work.
If the remote server request fails, then an Internal Server error should instead be presented.

Catch `HttpServerErrorException` and `HttpClientErrorException` exceptions when calling `restTemplate.getForObject()`.

Provide a new exception, called `RemoteServerError` that provides specific error handling and reporting.
The `RemoteServerError` will present a simplified error message to the user, in JSON.
A log will be written to that provides additional details, such as the URL.
The original response payload will be in the log message, which is likely to be HTML.

The following is an example log snippet:
```
2025-11-21 10:11:22.058 ERROR 25530 --- [nio-9000-exec-1] e.t.c.exception.RestExceptionHandler     : Failed to GET https://localhost/bad_url_test/oai?verb=GetRecord&met
  404 Not Found: "<html><EOL><EOL><head><title>404 Not Found</title></head><EOL><EOL><body><EOL><EOL><center><h1>404 Not Found</h1></center><EOL><EOL><hr><center>nginx</center><EOL><EOL></bo
edu.tamu.catalog.exception.RemoteServerError: Failed to access remote server for folio catalog due to 404 NOT_FOUND.
  at edu.tamu.catalog.service.FolioCatalogService.restGet(FolioCatalogService.java:1561)
  at edu.tamu.catalog.service.FolioCatalogService.requestHoldings(FolioCatalogService.java:703)
  at edu.tamu.catalog.service.FolioCatalogService.getHoldingsByBibId(FolioCatalogService.java:182)
  at edu.tamu.catalog.controller.CatalogAccessController.getHoldings(CatalogAccessController.java:34)
```
