### PR TITLE
Issue #221: Update base image version from jammy to noble

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,9 @@ RUN groupadd --non-unique -g $USER_ID $USER_NAME && \
     useradd --non-unique -d /$USER_NAME -m -u $USER_ID -g $USER_ID $USER_NAME
 
 RUN apt-get update -u && \
-    apt-get upgrade -y
+    apt-get upgrade -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Login as user.
 USER $USER_NAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ USER $USER_NAME
 RUN mvn package -Pjar -DskipTests=true
 
 # Switch to Normal JRE Stage.
-FROM eclipse-temurin:11-jre-jammy
+FROM eclipse-temurin:11-jre-noble
 ARG USER_ID
 ARG USER_NAME
 ARG SOURCE_DIR
@@ -50,6 +50,9 @@ ARG SOURCE_DIR
 # Create the user and group (use a high ID to attempt to avoid conflicts).
 RUN groupadd --non-unique -g $USER_ID $USER_NAME && \
     useradd --non-unique -d /$USER_NAME -m -u $USER_ID -g $USER_ID $USER_NAME
+
+RUN apt-get update -u && \
+    apt-get upgrade -y
 
 # Login as user.
 USER $USER_NAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG USER_NAME=catalog
 ARG SOURCE_DIR=/$USER_NAME/source
 
 # Maven stage.
-FROM eclipse-temurin:11-jdk-jammy as maven
+FROM eclipse-temurin:11-jdk-noble as maven
 ARG USER_ID
 ARG USER_NAME
 ARG SOURCE_DIR


### PR DESCRIPTION
Resolves https://github.com/TAMULib/CatalogService/issues/221

jammy image: C-4, H-34, M-61, L-61 vs. noble image: C-4, H-23, M-49, L-33

(I tested on dev.)