### PR TITLE
Issue 223: Improve error handling and processing of OKAPI response.

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -114,6 +114,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-plugins.version}</version>
+        <configuration>
+          <trimStackTrace>false</trimStackTrace>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/service/src/main/java/edu/tamu/catalog/advice/AbstractAdvice.java
+++ b/service/src/main/java/edu/tamu/catalog/advice/AbstractAdvice.java
@@ -1,0 +1,103 @@
+package edu.tamu.catalog.advice;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.tamu.catalog.enums.ResponseItemEnum;
+import edu.tamu.catalog.response.JsonResponse;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+/**
+ * Provide basic error handling and reporting, defaulting as JSON responses.
+ */
+public abstract class AbstractAdvice extends RequestMappingHandlerMapping {
+
+  /**
+   * Get the object mapper.
+   *
+   * @return objectMapper The object mapper.
+   */
+  protected abstract ObjectMapper getObjectMapper();
+
+  /**
+   * Build the error message, with default JSON media type.
+   *
+   * @param ex   The exception.
+   * @param code The HTTP Status Code.
+   *
+   * @return The built error response entity.
+   */
+  protected ResponseEntity<String> buildError(Exception ex, HttpStatus code) {
+
+    return buildError(ex, code, MediaType.APPLICATION_JSON);
+  }
+
+  /**
+   * Build the error message without using custom message.
+   *
+   * @param ex   The exception.
+   * @param code The HTTP Status Code.
+   * @param type The media type to use.
+   *
+   * @return The built error response entity.
+   */
+  protected ResponseEntity<String> buildError(Exception ex, HttpStatus code, MediaType type) {
+
+    return buildError(ex, code, type, null);
+  }
+
+  /**
+   * Build the error message.
+   *
+   * Only the JSON media type is converted, all others are passed through as-is.
+   *
+   * This will log non-empty details to the console log if the exception is an instance of AbstractDetailException.
+   *
+   * @param ex      The exception.
+   * @param code    The HTTP Status Code.
+   * @param type    The media type to use.
+   * @param message A custom error message to use rather than from a stack trace. If NULL, then the stack trace message is used.
+   *
+   * @return The built error response entity.
+   *
+   * @throws JsonProcessingException on error.
+   */
+  protected ResponseEntity<String> buildError(Exception ex, HttpStatus code, MediaType type, String message) {
+
+    final String item = message == null && ex != null ? ex.getMessage() : message;
+    String response = item;
+
+    logger.error(response, logger.isDebugEnabled() ? ex : null);
+
+    if (type == MediaType.APPLICATION_JSON) {
+      final List<String> items = item == null ? new ArrayList<>() : List.of(item);
+      final JsonResponse<String> json = new JsonResponse<>();
+
+      json.setStatus(code);
+      json.setType(ResponseItemEnum.STRING.toString().toLowerCase());
+      json.setTotal(items.size());
+      json.setItems(items);
+
+      try {
+        response = getObjectMapper().writeValueAsString(json);
+      } catch (JsonProcessingException e) {
+        if (items.isEmpty()) {
+          response = items.get(0);
+        } else {
+          response = ex == null ? "" : ex.getMessage();
+        }
+
+        logger.error("Failed to perform JSON deserialization when constructing the error response packet, falling back to raw string", e);
+      }
+    }
+
+    return ResponseEntity.status(code)
+      .contentType(type)
+      .body(response);
+  }
+
+}

--- a/service/src/main/java/edu/tamu/catalog/advice/IndexAdvice.java
+++ b/service/src/main/java/edu/tamu/catalog/advice/IndexAdvice.java
@@ -1,0 +1,90 @@
+package edu.tamu.catalog.advice;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+/**
+ * The index end point exception to REST response converter.
+ *
+ * This is also used as a global exception handler.
+ */
+@ControllerAdvice
+public class IndexAdvice extends AbstractAdvice {
+
+  /**
+   * The object mapper for this class.
+   */
+  final ObjectMapper objectMapper;
+
+  /**
+   * Initializer.
+   *
+   * @param objectMapper The object mapper.
+   */
+  IndexAdvice(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<String> handleHttpMessageNotReadableException(HttpMessageNotReadableException exception) {
+
+    return buildError(exception, HttpStatus.BAD_REQUEST, MediaType.APPLICATION_JSON, "Invalid request received.");
+  }
+
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException exception) {
+
+    return buildError(exception, HttpStatus.BAD_REQUEST);
+  }
+
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(UnsupportedOperationException.class)
+  public ResponseEntity<String> handleUnsupportedOperationException(UnsupportedOperationException exception) {
+
+    return buildError(exception, HttpStatus.BAD_REQUEST);
+  }
+
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  @ExceptionHandler(NoHandlerFoundException.class)
+  public ResponseEntity<String> handleNoHandlerFoundException(NoHandlerFoundException exception) {
+
+    return buildError(exception, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(HttpClientErrorException.class)
+  public ResponseEntity<String> handleHttpClientErrorException(HttpClientErrorException exception) {
+
+    return buildError(exception, exception.getStatusCode());
+  }
+
+  @ExceptionHandler(HttpServerErrorException.class)
+  public ResponseEntity<String> handleHttpServerErrorException(HttpServerErrorException exception) {
+
+    return buildError(exception, exception.getStatusCode());
+  }
+
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  @ExceptionHandler(RuntimeException.class)
+  public ResponseEntity<String> handleRuntimeException(RuntimeException exception) {
+
+    return buildError(exception, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @Override
+  protected ObjectMapper getObjectMapper() {
+
+    return objectMapper;
+  }
+
+}

--- a/service/src/main/java/edu/tamu/catalog/enums/ResponseItemEnum.java
+++ b/service/src/main/java/edu/tamu/catalog/enums/ResponseItemEnum.java
@@ -1,0 +1,25 @@
+package edu.tamu.catalog.enums;
+
+/**
+ * Response types for JsonResponse items.
+ */
+public enum ResponseItemEnum {
+
+  /**
+   * The response type is in HTML.
+   */
+  HTML,
+
+  /**
+   * The response type is in JSON with no explicitly defined structure.
+   *
+   * This could included embedded JsonResponse.
+   */
+  JSON,
+
+  /**
+   * The response type is text of no described structure.
+   */
+  STRING,
+
+}

--- a/service/src/main/java/edu/tamu/catalog/exception/CatalogHttpClientException.java
+++ b/service/src/main/java/edu/tamu/catalog/exception/CatalogHttpClientException.java
@@ -1,0 +1,56 @@
+package edu.tamu.catalog.exception;
+
+import java.nio.charset.Charset;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
+import org.springframework.web.client.HttpClientErrorException;
+
+public class CatalogHttpClientException extends HttpClientErrorException {
+
+  private static final long serialVersionUID = 3251327121684311289L;
+
+  /**
+   * Constructor with a status code only.
+   */
+  public CatalogHttpClientException(HttpStatus statusCode) {
+    super(statusCode);
+  }
+
+  /**
+   * Constructor with a status code and status text.
+   */
+  public CatalogHttpClientException(HttpStatus statusCode, String statusText) {
+    super(statusCode, statusText);
+  }
+
+  /**
+   * Constructor with a status code and status text, and content.
+   */
+  public CatalogHttpClientException(
+      HttpStatus statusCode, String statusText, @Nullable byte[] body, @Nullable Charset responseCharset) {
+
+    super(statusCode, statusText, body, responseCharset);
+  }
+
+  /**
+   * Constructor with a status code and status text, headers, and content.
+   */
+  public CatalogHttpClientException(HttpStatus statusCode, String statusText,
+      @Nullable HttpHeaders headers, @Nullable byte[] body, @Nullable Charset responseCharset) {
+
+    super(statusCode, statusText, headers, body, responseCharset);
+  }
+
+  /**
+   * Constructor with a status code and status text, headers, and content,
+   * and a prepared message.
+   * @since 5.2.2
+   */
+  public CatalogHttpClientException(String message, HttpStatus statusCode, String statusText,
+      @Nullable HttpHeaders headers, @Nullable byte[] body, @Nullable Charset responseCharset) {
+
+    super(message, statusCode, statusText, headers, body, responseCharset);
+  }
+
+}

--- a/service/src/main/java/edu/tamu/catalog/exception/CatalogHttpServerException.java
+++ b/service/src/main/java/edu/tamu/catalog/exception/CatalogHttpServerException.java
@@ -1,0 +1,56 @@
+package edu.tamu.catalog.exception;
+
+import java.nio.charset.Charset;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
+import org.springframework.web.client.HttpServerErrorException;
+
+public class CatalogHttpServerException extends HttpServerErrorException {
+
+  private static final long serialVersionUID = 346211115584311289L;
+
+  /**
+   * Constructor with a status code only.
+   */
+  public CatalogHttpServerException(HttpStatus statusCode) {
+    super(statusCode);
+  }
+
+  /**
+   * Constructor with a status code and status text.
+   */
+  public CatalogHttpServerException(HttpStatus statusCode, String statusText) {
+    super(statusCode, statusText);
+  }
+
+  /**
+   * Constructor with a status code and status text, and content.
+   */
+  public CatalogHttpServerException(
+      HttpStatus statusCode, String statusText, @Nullable byte[] body, @Nullable Charset responseCharset) {
+
+    super(statusCode, statusText, body, responseCharset);
+  }
+
+  /**
+   * Constructor with a status code and status text, headers, and content.
+   */
+  public CatalogHttpServerException(HttpStatus statusCode, String statusText,
+      @Nullable HttpHeaders headers, @Nullable byte[] body, @Nullable Charset responseCharset) {
+
+    super(statusCode, statusText, headers, body, responseCharset);
+  }
+
+  /**
+   * Constructor with a status code and status text, headers, and content,
+   * and a prepared message.
+   * @since 5.2.2
+   */
+  public CatalogHttpServerException(String message, HttpStatus statusCode, String statusText,
+      @Nullable HttpHeaders headers, @Nullable byte[] body, @Nullable Charset responseCharset) {
+
+    super(message, statusCode, statusText, headers, body, responseCharset);
+  }
+
+}

--- a/service/src/main/java/edu/tamu/catalog/response/JsonResponse.java
+++ b/service/src/main/java/edu/tamu/catalog/response/JsonResponse.java
@@ -1,0 +1,93 @@
+package edu.tamu.catalog.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Provide a basic top-level structure for all JSON response types.
+ *
+ * This is designed around the JDK14+ `record` type.
+ *
+ * @param <T>    The item list type (this can be something as simple as a string).
+ * @param status The HTTP Response status (added to the object in addition to the HTTP header).
+ * @param type   The type of this message (as a string to act as a generic or abstract structure).
+ * @param total  The total number of rows in the items array.
+ * @param items  An array of all items attached (this can be any structure and can even be recursive to some extent).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JsonResponse<T> implements Serializable {
+
+  private static final long serialVersionUID = 32112693629109L;
+
+  @JsonProperty("status")
+  private HttpStatus status;
+
+  @JsonProperty("type")
+  private String type;
+
+  @JsonProperty("total")
+  private Integer total;
+
+  @JsonProperty("items")
+  private List<T> items;
+
+  /**
+   * @return the status
+   */
+  public HttpStatus getStatus() {
+    return status;
+  }
+
+  /**
+   * @param status the status to set
+   */
+  public void setStatus(HttpStatus status) {
+    this.status = status;
+  }
+
+  /**
+   * @return the type
+   */
+  public String getType() {
+    return type;
+  }
+
+  /**
+   * @param type the type to set
+   */
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  /**
+   * @return the total
+   */
+  public Integer getTotal() {
+    return total;
+  }
+
+  /**
+   * @param total the total to set
+   */
+  public void setTotal(Integer total) {
+    this.total = total;
+  }
+
+  /**
+   * @return the items
+   */
+  public List<T> getItems() {
+    return items;
+  }
+
+  /**
+   * @param items the items to set
+   */
+  public void setItems(List<T> items) {
+    this.items = items;
+  }
+
+}

--- a/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
+++ b/service/src/main/java/edu/tamu/catalog/service/FolioCatalogService.java
@@ -31,6 +31,8 @@ import edu.tamu.catalog.domain.model.HoldRequest;
 import edu.tamu.catalog.domain.model.HoldingsRecord;
 import edu.tamu.catalog.domain.model.LoanItem;
 import edu.tamu.catalog.domain.model.Note;
+import edu.tamu.catalog.exception.CatalogHttpClientException;
+import edu.tamu.catalog.exception.CatalogHttpServerException;
 import edu.tamu.catalog.exception.RenewFailureException;
 import edu.tamu.catalog.model.FolioHoldCancellation;
 import edu.tamu.catalog.model.FolioToken;
@@ -185,22 +187,24 @@ public class FolioCatalogService implements CatalogService {
 
         List<FeeFine> list = new ArrayList<>();
 
-        JsonNode charges = node.at("/charges");
+        if (node != null) {
+            JsonNode charges = node.at("/charges");
 
-        if (charges.isContainerNode() && charges.isArray()) {
-            Iterator<JsonNode> iter = charges.elements();
+            if (charges.isContainerNode() && charges.isArray()) {
+                Iterator<JsonNode> iter = charges.elements();
 
-            while (iter.hasNext()) {
-                JsonNode charge = iter.next();
-                list.add(FeeFine.builder()
-                    .fineId(getText(charge, "/feeFineId"))
-                    .itemId(getText(charge, "/item/itemId"))
-                    .instanceId(getText(charge, "/item/instanceId"))
-                    .fineType(getText(charge, "/reason"))
-                    .fineDate(getDate(charge, "/accrualDate"))
-                    .itemTitle(getText(charge, "/item/title"))
-                    .amount(getDouble(charge, "/chargeAmount/amount", 0))
-                    .build());
+                while (iter.hasNext()) {
+                    JsonNode charge = iter.next();
+                    list.add(FeeFine.builder()
+                        .fineId(getText(charge, "/feeFineId"))
+                        .itemId(getText(charge, "/item/itemId"))
+                        .instanceId(getText(charge, "/item/instanceId"))
+                        .fineType(getText(charge, "/reason"))
+                        .fineDate(getDate(charge, "/accrualDate"))
+                        .itemTitle(getText(charge, "/item/title"))
+                        .amount(getDouble(charge, "/chargeAmount/amount", 0))
+                        .build());
+                }
             }
         }
 
@@ -443,10 +447,17 @@ public class FolioCatalogService implements CatalogService {
     JsonNode okapiRequestJsonNode(String url, HttpMethod method, String message) {
         String errorReason = null;
 
+        HttpEntity<?> requestEntity = new HttpEntity<>(headers(properties.getTenant(), getOkapiToken()));
+
         try {
-            ResponseEntity<JsonNode> response = okapiRequest(url, method, JsonNode.class);
-            if (Objects.nonNull(response) && response.getBody().isContainerNode()) {
-                return response.getBody();
+            ResponseEntity<JsonNode> response = okapiRequest(url, method, requestEntity, JsonNode.class);
+
+            if (response != null) {
+              JsonNode node = response.getBody();
+
+              if (node != null && node.isContainerNode()) {
+                return node;
+              }
             }
 
             errorReason = "Invalid body in the HTTP response";
@@ -478,18 +489,30 @@ public class FolioCatalogService implements CatalogService {
       * @return response entity with response type as body.
       */
     JsonNode okapiRequestJsonNode(String url, HttpMethod method, String message, Object... uriVariables) {
+
+        HttpEntity<?> requestEntity = new HttpEntity<>(headers(properties.getTenant(), getOkapiToken()));
+
         try {
-            ResponseEntity<JsonNode> response = okapiRequest(url, method, JsonNode.class, uriVariables);
-            if (Objects.nonNull(response) && response.getBody().isContainerNode()) {
-                return response.getBody();
+            ResponseEntity<JsonNode> response = okapiRequest(url, method, requestEntity, JsonNode.class, uriVariables);
+
+            if (response != null) {
+              JsonNode node = response.getBody();
+
+              if (node != null && node.isContainerNode()) {
+                return node;
+              }
             }
         }
         catch (HttpClientErrorException e) {
-            throw new HttpClientErrorException(e.getStatusCode(),
+            logger.error(String.format("%s: Request failed for %s: %s", e.getStatusCode(), url, e.getMessage()));
+
+            throw new CatalogHttpClientException(e.getStatusCode(),
                 String.format("%s: Catalog service failed to find %s.", e.getStatusText(), message));
         }
         catch (HttpServerErrorException e) {
-            throw new HttpServerErrorException(e.getStatusCode(),
+            logger.error(String.format("%s: Request failed for %s: %s", e.getStatusCode(), url, e.getMessage()));
+
+            throw new CatalogHttpServerException(e.getStatusCode(),
                 String.format("%s: Catalog service failed to find %s.", e.getStatusText(), message));
         }
         HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
@@ -503,15 +526,15 @@ public class FolioCatalogService implements CatalogService {
      * @param <T> generic class for response body type.
      * @param url String
      * @param method HttpMethod
+     * @param requestEntity The entity containing the tenant properties and authentication token.
      * @param responseType Class<T>
      * @param uriVariables Object... uri variables to be expanded into url.
      *
      * @return response entity with response type as body
      */
-    <T> ResponseEntity<T> okapiRequest(String url, HttpMethod method, Class<T> responseType, Object... uriVariables) {
-        HttpEntity<?> requestEntity = new HttpEntity<>(headers(properties.getTenant(), getOkapiToken()));
+    <T> ResponseEntity<T> okapiRequest(String url, HttpMethod method, HttpEntity<?> requestEntity, Class<T> responseType, Object... uriVariables) {
 
-        return okapiRequest(1, url, method, requestEntity, responseType, uriVariables);
+        return okapiRequestRetry(1, url, method, requestEntity, responseType, uriVariables);
     }
 
     /**
@@ -530,7 +553,7 @@ public class FolioCatalogService implements CatalogService {
     <B,T> ResponseEntity<T> okapiRequest(String url, HttpMethod method, B body, Class<T> responseType, Object... uriVariables) {
         HttpEntity<B> requestEntity = new HttpEntity<>(body, headers(properties.getTenant(), getOkapiToken()));
 
-        return okapiRequest(1, url, method, requestEntity, responseType, uriVariables);
+        return okapiRequestRetry(1, url, method, requestEntity, responseType, uriVariables);
     }
 
     /**
@@ -728,73 +751,76 @@ public class FolioCatalogService implements CatalogService {
             }
 
             JsonNode okapiHoldings = getOkapiHoldings(instanceId);
-            okapiHoldings.forEach(holding -> {
-                String hrid = holding.at("/hrid").asText();
-                JsonNode holdingLocationNode = getLocation(holding.at("/permanentLocationId").asText());
-                String fallbackLocationCode = holdingLocationNode.at("/code").asText();
-                String holdingLocationName = holdingLocationNode.at("/discoveryDisplayName").asText();
-                String holdingCallNumber = holding.at("/callNumber").asText();
-                String holdingCallNumberPrefix = holding.at("/callNumberPrefix").asText();
 
-                List<Note> holdingNotes = new ArrayList<Note>();
-                holding.at("/notes").forEach(note -> {
-                    holdingNotes.add(Note.builder().note(note.at("/note").asText()).isStaffOnly(note.at("/staffOnly").asBoolean())
-                        .noteTypeId(note.at("/holdingsNoteTypeId").asText()).build());
-                });
+            if (okapiHoldings != null) {
+              okapiHoldings.forEach(holding -> {
+                  String hrid = holding.at("/hrid").asText();
+                  JsonNode holdingLocationNode = getLocation(holding.at("/permanentLocationId").asText());
+                  String fallbackLocationCode = holdingLocationNode.at("/code").asText();
+                  String holdingLocationName = holdingLocationNode.at("/discoveryDisplayName").asText();
+                  String holdingCallNumber = holding.at("/callNumber").asText();
+                  String holdingCallNumberPrefix = holding.at("/callNumberPrefix").asText();
 
-                List<String> holdingStatements = new ArrayList<String>();
+                  List<Note> holdingNotes = new ArrayList<Note>();
+                  holding.at("/notes").forEach(note -> {
+                      holdingNotes.add(Note.builder().note(note.at("/note").asText()).isStaffOnly(note.at("/staffOnly").asBoolean())
+                          .noteTypeId(note.at("/holdingsNoteTypeId").asText()).build());
+                  });
 
-                ArrayNode holdingsStatements = (ArrayNode) holding.at("/holdingsStatements");
-                logger.info("{} {} is still empty", holdingsStatements, holdingsStatements.isEmpty());
+                  List<String> holdingStatements = new ArrayList<String>();
 
-                holdingsStatements.forEach(statementNode -> {
-                    if (statementNode.has("statement")) {
-                        holdingStatements.add(statementNode.get("statement").asText());
-                    } else {
-                        logger.info("Missing statement on holdings statement.", statementNode.get("statement"));
-                    }
-                });
+                  ArrayNode holdingsStatements = (ArrayNode) holding.at("/holdingsStatements");
+                  logger.info("{} {} is still empty", holdingsStatements, holdingsStatements.isEmpty());
 
-                //get items for holding from okapi
-                Map<String, Map<String,String>> okapiItems = getOkapiItems(holding.at("/id").asText());
+                  holdingsStatements.forEach(statementNode -> {
+                      if (statementNode.has("statement")) {
+                          holdingStatements.add(statementNode.get("statement").asText());
+                      } else {
+                          logger.info("Missing statement on holdings statement.");
+                      }
+                  });
 
-                //combine marc based holding data and direct okapi data
-                HoldingsRecord recordValues = marcHoldings.get(0);
-                HoldingsRecord currentHolding = HoldingsRecord.builder()
-                                .recordId(recordValues.getRecordId())
-                                .marcRecordLeader(recordValues.getMarcRecordLeader())
-                                .mfhd(hrid)
-                                .issn(recordValues.getIssn())
-                                .isbn(recordValues.getIsbn())
-                                .title(recordValues.getTitle())
-                                .author(recordValues.getAuthor())
-                                .publisher(recordValues.getPublisher())
-                                .place(recordValues.getPlace())
-                                .year(recordValues.getYear())
-                                .genre(recordValues.getGenre())
-                                .fallbackLocationCode(fallbackLocationCode)
-                                .holdingLocation(holdingLocationName)
-                                .edition(recordValues.getEdition())
-                                .oclc(recordValues.getOclc())
-                                .recordId(recordValues.getRecordId())
-                                .callNumber(holdingCallNumber)
-                                .callNumberPrefix(holdingCallNumberPrefix)
-                                .largeVolume(recordValues.isLargeVolume())
-                                .catalogItems(okapiItems.size() > 0 ? okapiItems:recordValues.getCatalogItems())
-                                .holdingNotes(holdingNotes)
-                                .holdingStatements(holdingStatements)
-                                .build();
+                  //get items for holding from okapi
+                  Map<String, Map<String,String>> okapiItems = getOkapiItems(holding.at("/id").asText());
 
-                finalHoldings.add(currentHolding);
+                  //combine marc based holding data and direct okapi data
+                  HoldingsRecord recordValues = marcHoldings.get(0);
+                  HoldingsRecord currentHolding = HoldingsRecord.builder()
+                                  .recordId(recordValues.getRecordId())
+                                  .marcRecordLeader(recordValues.getMarcRecordLeader())
+                                  .mfhd(hrid)
+                                  .issn(recordValues.getIssn())
+                                  .isbn(recordValues.getIsbn())
+                                  .title(recordValues.getTitle())
+                                  .author(recordValues.getAuthor())
+                                  .publisher(recordValues.getPublisher())
+                                  .place(recordValues.getPlace())
+                                  .year(recordValues.getYear())
+                                  .genre(recordValues.getGenre())
+                                  .fallbackLocationCode(fallbackLocationCode)
+                                  .holdingLocation(holdingLocationName)
+                                  .edition(recordValues.getEdition())
+                                  .oclc(recordValues.getOclc())
+                                  .recordId(recordValues.getRecordId())
+                                  .callNumber(holdingCallNumber)
+                                  .callNumberPrefix(holdingCallNumberPrefix)
+                                  .largeVolume(recordValues.isLargeVolume())
+                                  .catalogItems(okapiItems.size() > 0 ? okapiItems:recordValues.getCatalogItems())
+                                  .holdingNotes(holdingNotes)
+                                  .holdingStatements(holdingStatements)
+                                  .build();
 
-                logger.debug("Record ID: {}", currentHolding.getRecordId());
-                logger.debug("Marc record leader: {}", currentHolding.getMarcRecordLeader());
-                logger.debug("MFHD: {}", currentHolding.getMfhd());
-                logger.debug("ISBN: {}", currentHolding.getIsbn());
-                logger.debug("Fallback location: {}", currentHolding.getFallbackLocationCode());
-                logger.debug("Call number: {} {}", holdingCallNumberPrefix, holdingCallNumber);
-                logger.debug("Valid large volume: {}", currentHolding.isLargeVolume());
-            });
+                  finalHoldings.add(currentHolding);
+
+                  logger.debug("Record ID: {}", currentHolding.getRecordId());
+                  logger.debug("Marc record leader: {}", currentHolding.getMarcRecordLeader());
+                  logger.debug("MFHD: {}", currentHolding.getMfhd());
+                  logger.debug("ISBN: {}", currentHolding.getIsbn());
+                  logger.debug("Fallback location: {}", currentHolding.getFallbackLocationCode());
+                  logger.debug("Call number: {} {}", holdingCallNumberPrefix, holdingCallNumber);
+                  logger.debug("Valid large volume: {}", currentHolding.isLargeVolume());
+              });
+            }
 
         } catch (DOMException | IOException | ParserConfigurationException | SAXException e) {
             // TODO: consider throwing all of these so that caller can handle more appropriately.
@@ -935,7 +961,7 @@ public class FolioCatalogService implements CatalogService {
         Map<String, Map<String, String>> catalogItems = new HashMap<String, Map<String, String>>();
 
         for (int i = 0; i < marcListCount; i++) {
-            if (nodeNameMatches(marcList.item(i).getNodeName().toString(), NODE_DATA_FIELD) &&
+            if (nodeNameMatches(marcList.item(i).getNodeName(), NODE_DATA_FIELD) &&
                 Marc21Xml.attributeTagMatches(marcList.item(i), "952")) {
                 NodeList childNodes = marcList.item(i).getChildNodes();
                 for (int j = 0; j < childNodes.getLength(); j++) {
@@ -1059,12 +1085,21 @@ public class FolioCatalogService implements CatalogService {
         Integer limit = loanIdsPartitions.size();
         String ids = String.join(" OR ", loanIdsPartitions);
         String url = String.format("%s/circulation/loans?limit={limit}&query=id==({ids})", baseOkapiUrl);
-        ResponseEntity<JsonNode> response = okapiRequest(url, HttpMethod.GET, JsonNode.class, limit, ids);
-        if (response.hasBody()) {
-            JsonNode loansNode = response.getBody().get("loans");
-            if (loansNode.isArray()) {
-                return loansNode;
+
+        HttpEntity<?> requestEntity = new HttpEntity<>(headers(properties.getTenant(), getOkapiToken()));
+
+        ResponseEntity<JsonNode> response = okapiRequest(url, HttpMethod.GET, requestEntity, JsonNode.class, limit, ids);
+
+        if (response != null) {
+          JsonNode node = response.getBody();
+
+          if (node != null) {
+            JsonNode loansNode = node.get("loans");
+
+            if (loansNode != null && loansNode.isArray()) {
+              return loansNode;
             }
+          }
         }
 
         return objectMapper.createObjectNode();
@@ -1102,12 +1137,21 @@ public class FolioCatalogService implements CatalogService {
         Integer limit = instanceIdsBatch.size();
         String ids = String.join(" OR ", instanceIdsBatch);
         String url = String.format("%s/instance-storage/instances?limit={limit}&query=id==({ids})", baseOkapiUrl);
-        ResponseEntity<JsonNode> response = okapiRequest(url, HttpMethod.GET, JsonNode.class, limit, ids);
-        if (response.hasBody()) {
-            JsonNode instancesNode = response.getBody().get("instances");
-            if (instancesNode.isArray()) {
-                return instancesNode;
+
+        HttpEntity<?> requestEntity = new HttpEntity<>(headers(properties.getTenant(), getOkapiToken()));
+
+        ResponseEntity<JsonNode> response = okapiRequest(url, HttpMethod.GET, requestEntity, JsonNode.class, limit, ids);
+
+        if (response != null) {
+          JsonNode node = response.getBody();
+
+          if (node != null) {
+            JsonNode instancesNode = node.get("instances");
+
+            if (instancesNode != null && instancesNode.isArray()) {
+              return instancesNode;
             }
+          }
         }
 
         return objectMapper.createObjectNode();
@@ -1145,12 +1189,21 @@ public class FolioCatalogService implements CatalogService {
         Integer limit = itemIdsBatch.size();
         String ids = String.join(" OR ", itemIdsBatch);
         String url = String.format("%s/inventory/items?limit={limit}&query=id==({ids})", baseOkapiUrl);
-        ResponseEntity<JsonNode> response = okapiRequest(url, HttpMethod.GET, JsonNode.class, limit, ids);
-        if (response.hasBody()) {
-            JsonNode itemsNode = response.getBody().get("items");
-            if (itemsNode.isArray()) {
-                return itemsNode;
+
+        HttpEntity<?> requestEntity = new HttpEntity<>(headers(properties.getTenant(), getOkapiToken()));
+
+        ResponseEntity<JsonNode> response = okapiRequest(url, HttpMethod.GET, requestEntity, JsonNode.class, limit, ids);
+
+        if (response != null) {
+          JsonNode node = response.getBody();
+
+          if (node != null) {
+            JsonNode itemsNode = node.get("items");
+
+            if (itemsNode != null && itemsNode.isArray()) {
+              return itemsNode;
             }
+          }
         }
 
         return objectMapper.createObjectNode();
@@ -1342,12 +1395,14 @@ public class FolioCatalogService implements CatalogService {
      * @throws Exception
      */
     private Date getDate(JsonNode input, String jsonPtrExpr) throws Exception {
+        if (input == null) return null;
+
         JsonNode property = input.at(jsonPtrExpr);
         return property.isValueNode() ? FolioDateTime.parse(property.asText()) : null;
     }
 
     /**
-     * Okapi request method to attempt one token refresh and retry if request unauthorized.
+     * Okapi request method to attempt one token refresh and retry if request unauthorized with retry support.
      *
      * Do not pass "{baseOkapiUrl}".
      * Instead, convert it before sending it to this function because restTemplate.exchange() is always forcing a leading '/'.
@@ -1363,14 +1418,14 @@ public class FolioCatalogService implements CatalogService {
      *
      * @return response entity with response type as body
      */
-    private <T> ResponseEntity<T> okapiRequest(int attempt, String url, HttpMethod method, HttpEntity<?> requestEntity, Class<T> responseType, Object... uriVariables) {
+    private <T> ResponseEntity<T> okapiRequestRetry(int attempt, String url, HttpMethod method, HttpEntity<?> requestEntity, Class<T> responseType, Object... uriVariables) {
         try {
-            return restTemplate.exchange(url, method, requestEntity, responseType, uriVariables);
+          return restTemplate.exchange(url, method, requestEntity, responseType, uriVariables);
         } catch(RestClientResponseException e) {
             if (e.getRawStatusCode() == HttpStatus.UNAUTHORIZED.value() && attempt == 1) {
                 requestEntity = new HttpEntity<>(requestEntity.getBody(), headers(properties.getTenant(), getOkapiToken()));
 
-                return okapiRequest(++attempt, url, method, requestEntity, responseType, uriVariables);
+                return okapiRequestRetry(++attempt, url, method, requestEntity, responseType, uriVariables);
             }
 
             throw e;
@@ -1413,28 +1468,34 @@ public class FolioCatalogService implements CatalogService {
      */
     private FolioTokens okapiLogin() {
         String url = properties.getBaseOkapiUrl() + tokenConfig.getLoginPath();
-        HttpEntity<Credentials> entity = new HttpEntity<>(properties.getCredentials(), headers(properties.getTenant()));
-        ResponseEntity<?> response = restTemplate.postForEntity(url, entity, Object.class);
 
-        if (response.getStatusCode().equals(HttpStatus.CREATED)) {
-            FolioTokens folioTokens = null;
+        try {
+          HttpEntity<Credentials> entity = new HttpEntity<>(properties.getCredentials(), headers(properties.getTenant()));
+          ResponseEntity<?> response = restTemplate.postForEntity(url, entity, Object.class);
 
-            for (Map.Entry<String, List<String>> map : response.getHeaders().entrySet()) {
-                if (SET_COOKIE_HEADER.equalsIgnoreCase(map.getKey())) {
-                    folioTokens = extractFolioTokensByName(map.getValue());
+          if (response.getStatusCode().equals(HttpStatus.CREATED)) {
+              FolioTokens folioTokens = null;
 
-                    if (folioTokens != null) {
-                        FolioTokenUtility.setTokens(getName(), folioTokens);
+              for (Map.Entry<String, List<String>> map : response.getHeaders().entrySet()) {
+                  if (SET_COOKIE_HEADER.equalsIgnoreCase(map.getKey())) {
+                      folioTokens = extractFolioTokensByName(map.getValue());
 
-                        return folioTokens;
-                    }
-                }
-            }
+                      if (folioTokens != null) {
+                          FolioTokenUtility.setTokens(getName(), folioTokens);
 
-            logger.error("Failed to login, missing/invalid token headers: {} and {}.", tokenConfig.getAccessCookieName(),
-                tokenConfig.getRefreshCookieName());
-        } else {
-            logger.error("Failed to login {}: {}", response.getStatusCodeValue(), response.getBody());
+                          return folioTokens;
+                      }
+                  }
+              }
+
+              logger.error("Failed to login, missing/invalid token headers: {} and {}.", tokenConfig.getAccessCookieName(),
+                  tokenConfig.getRefreshCookieName());
+          } else {
+              logger.error("Failed to login {}: {}", response.getStatusCodeValue(), response.getBody());
+          }
+        }
+        catch (Exception e) {
+          logger.error("Catalog service failed to login into Okapi: " + e.getMessage() + "!");
         }
 
         throw new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "Catalog service failed to login into Okapi!");

--- a/service/src/main/java/edu/tamu/catalog/utility/FolioTokenUtility.java
+++ b/service/src/main/java/edu/tamu/catalog/utility/FolioTokenUtility.java
@@ -25,7 +25,7 @@ public class FolioTokenUtility {
     }
 
     /**
-     * Retreive the FOLIO tokens for the given catalog name.
+     * Retrieve the FOLIO tokens for the given catalog name.
      *
      * @param catalog The catalog name.
      *

--- a/service/src/test/java/edu/tamu/catalog/service/FolioCatalogServiceTest.java
+++ b/service/src/test/java/edu/tamu/catalog/service/FolioCatalogServiceTest.java
@@ -17,8 +17,12 @@ import edu.tamu.catalog.config.CatalogServiceConfig;
 import edu.tamu.catalog.config.FolioTenantConfig;
 import edu.tamu.catalog.config.FolioTokenConfig;
 import edu.tamu.catalog.config.RestConfig;
+import edu.tamu.catalog.model.FolioToken;
+import edu.tamu.catalog.model.FolioTokens;
 import edu.tamu.catalog.test.AbstractTestRestController;
 import edu.tamu.catalog.utility.FolioTokenUtility;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,14 +31,24 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
 @RestClientTest(FolioCatalogService.class)
-@Import({ CatalogServiceConfig.class, RestConfig.class, FolioTenantConfig.class , FolioTokenConfig.class })
-public class FolioCatalogServiceTest extends AbstractTestRestController {
+@Import({
+  CatalogServiceConfig.class,
+  RestConfig.class,
+  FolioTenantConfig.class,
+  FolioTokenConfig.class
+})
+class FolioCatalogServiceTest extends AbstractTestRestController {
+
+    private static final ZonedDateTime NEXT_YEAR = ZonedDateTime.now().plusYears(1);
 
     @Autowired
     private FolioCatalogService folioCatalogService;
@@ -48,19 +62,27 @@ public class FolioCatalogServiceTest extends AbstractTestRestController {
     @Autowired
     private FolioTokenConfig tokenConfig;
 
+    @Autowired
+    private FolioTenantConfig folioTenantConfig;
+
+    private FolioTokens folioTokens;
+
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() {
         buildRestServer(restTemplate, true);
         setTokenConfig(tokenConfig);
 
         FolioTokenUtility.clearAll();
 
-        expectOkapiLoginResponse(once(), withStatus(CREATED));
+        FolioToken access = new FolioToken(tokenConfig.getAccessCookieName(), NEXT_YEAR);
+        FolioToken refresh = new FolioToken(tokenConfig.getRefreshCookieName(), NEXT_YEAR);
+
+        folioTokens = new FolioTokens(access, refresh);
     }
 
     @ParameterizedTest
     @MethodSource("performOkapiRequests")
-    public void testOkapiRequests(String path, HttpMethod method, HttpStatus status, boolean withJson) throws Exception {
+    void testOkapiRequests(String path, HttpMethod method, HttpStatus status, boolean withJson) throws Exception {
         if (withJson) {
             JsonNode requestBody = objectMapper.createObjectNode();
             expectOkapiJsonResponse(path, method, once(), respondJsonAuto(requestBody, status));
@@ -68,7 +90,10 @@ public class FolioCatalogServiceTest extends AbstractTestRestController {
             expectOkapiResponse(path, method, once(), withStatus(status));
         }
 
-        ResponseEntity<JsonNode> entity = folioCatalogService.okapiRequest(getOkapiUrl(path), method, JsonNode.class);
+        HttpEntity<?> requestEntity = new HttpEntity<>(headers(folioTenantConfig.getDefaultTenant(), folioTokens.getAccess().getToken()));
+
+        String url = getOkapiUrl(path);
+        ResponseEntity<JsonNode> entity = folioCatalogService.okapiRequest(url, method, requestEntity, JsonNode.class);
 
         assertEquals(status, entity.getStatusCode(), "Received incorrect status for " + method.toString() + " /" + path + "");
         restServer.verify();
@@ -82,6 +107,20 @@ public class FolioCatalogServiceTest extends AbstractTestRestController {
           Arguments.of("locations/uuid", PUT, OK, true),
           Arguments.of("locations/uuid", DELETE, OK, false)
         );
+    }
+
+    private HttpHeaders headers(String tenant, String token) {
+      HttpHeaders headers = headers(tenant);
+      headers.set(tokenConfig.getHeaderName(), token);
+      return headers;
+    }
+
+    private HttpHeaders headers(String tenant) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set(folioTenantConfig.getHeaderName(), tenant);
+        return headers;
     }
 
 }

--- a/service/src/test/java/edu/tamu/catalog/test/AbstractTestRestController.java
+++ b/service/src/test/java/edu/tamu/catalog/test/AbstractTestRestController.java
@@ -15,7 +15,6 @@ import java.net.URL;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.text.MatchesPattern;
 import org.springframework.http.HttpHeaders;


### PR DESCRIPTION
Helps resolve #223 .

This should already work when replacing the **OKAPI** **URL** with the **KONG** **URL**. However, the error handling/reporting (and lack thereof) has made the process confusing and more problematic.

These changes help improve the design to improve the ability to investigate and handle problems with migrating to other services like **KONG**.

Ensure the **OKAPI** (or now **KONG**) response is in a separate `try..catch..` statement. This will help properly identify and report problems with communicating to **OKAPI**.

Bring in the controller advice and similar functionality from other repositories, like **IBIS**. This provides an actual response to the user on error. Previously an error would result in no response on curl commands. This is confusing and not ideal.

This also brings in the response **JSON** structure from **IBIS**. **IBIS** uses **Java** record types, but that is not available for this repository because **Java** records are not supported in **Java 11**. Implement this as a class with getters and setters.

Break apart the **HTTP** client and server errors into explicit exceptions so that they may be more explicitly handled.

Add and improve relevant NULL pointer checks in the **FOLIO** catalog service class. In particular, the `response.hasBody()` check could fail because `response` could be NULL. Then the `response.getBody()` can return NULL, so just check that for NULL directly rather than calling a function `hasBody()` to effectuate the NULL check. Repeat this logic for the `isArray()` call.

Remove unnecessary `.toString()` call.

Prevent NULL pointer problems in `getDate()` with `input` by adding an explicit check.

The unit test structure is changed to handle the new behavior where a separate request to **OKAPI** is being made. Disabling the trimming of the stack traces in exceptions so that unit test failures can be better interpreted.